### PR TITLE
Events

### DIFF
--- a/src/Stingray.jl
+++ b/src/Stingray.jl
@@ -42,7 +42,8 @@ export FITSMetadata,
     gti_info,
     gti_exposure,
     gti,
-    has_gti
+    has_gti,
+    extract_timing_keywords
 
 include("lightcurve.jl")
 export AbstractLightCurve,

--- a/src/events.jl
+++ b/src/events.jl
@@ -13,7 +13,7 @@ println(ev.meta.filepath)  # Shows the file path
 println(ev.meta.energy_units)  # Shows "PI", "ENERGY", or "PHA"
 ```
 """
-struct FITSMetadata{H}
+mutable struct FITSMetadata{H}
     "Path to the FITS file"
     filepath::String
     "HDU index that the metadata was read from"

--- a/src/events.jl
+++ b/src/events.jl
@@ -814,74 +814,201 @@ end
 """
     readevents(path; kwargs...)
 
-Read an [`EventList`](@ref) from a FITS file with optional GTI support. Will attempt to read an energy
-column if one exists.
+## Overview
 
-This is the primary function for loading X-ray event data from FITS files.
-It handles the complexities of different file formats and provides a consistent
-interface for accessing event data, including Good Time Intervals (GTIs).
+This module provides functionality for reading and manipulating X-ray event data from FITS files, with proper astronomical timing corrections and Good Time Interval (GTI) support. The primary focus is on timing accuracy following RXTE standards for X-ray astronomy.
 
-# Arguments
-- `path::AbstractString`: Path to the FITS file
+## Core Types
 
-# Keyword Arguments
-- `hdu::Int = 2`: HDU index to read from (typically 2 for event data)
-- `T::Type = Float64`: Type to cast the time and energy columns to
-- `sort::Bool = false`: Whether to sort by time if not already sorted
-- `extra_columns::Vector{String} = []`: Extra columns to read from the same HDU
-- `energy_alternatives::Vector{String} = ["ENERGY", "PI", "PHA"]`: Energy column alternatives to try
-- `load_gti::Bool = true`: Whether to attempt loading GTI information
-- `gti_hdu_candidates::Vector{String} = ["GTI", "STDGTI"]`: GTI HDU names to search for
-- `gti_hdu_indices::Vector{Int} = []`: GTI HDU indices to try if name search fails
-- `apply_gti_filter::Bool = false`: Whether to automatically filter events using GTI
+### `EventList{TimeType, MetaType}`
 
-# Returns
-`EventList{Vector{T}, FITSMetadata{FITSIO.FITSHeader}}`: EventList containing the event data and GTI metadata
+Container for X-ray event data with timing metadata.
 
-# Examples
+**Fields:**
+- `times::TimeType`: Vector of event times (typically in MJD(TT) after reading)
+- `energies::Union{Nothing, TimeType}`: Vector of event energies (keV, PI, or PHA units)
+- `meta::MetaType`: FITS metadata including timing keywords and GTI information
+
+### `FITSMetadata{H}`
+
+Metadata container for FITS file information and timing parameters.
+
+**Key Fields:**
+- `filepath::String`: Original FITS file path
+- `hdu::Int`: HDU index used for reading
+- `energy_units::Union{Nothing,String}`: Energy column name/units
+- `gti::Union{Nothing,Matrix{Float64}}`: GTI intervals (START, STOP columns)
+- `mjd_ref::Union{Nothing,Float64}`: MJD reference time (MJDREF or MJDREFI+MJDREFF)
+- `time_zero::Union{Nothing,Float64}`: Clock correction offset (TIMEZERO)
+- `time_unit::Union{Nothing,Float64}`: Time unit conversion factor
+- `time_sys::Union{Nothing,String}`: Time system (e.g., "TT", "UTC")
+- `time_pixr::Union{Nothing,Float64}`: Time pixel reference (TIMEPIXR)
+- `time_del::Union{Nothing,Float64}`: Time bin size (TIMEDEL)
+
+## Primary Functions
+
+### `readevents(path; kwargs...)`
+
+**Purpose:** Read X-ray event data from FITS files with automatic timing corrections.
+
+**Key Features:**
+- Converts raw mission times to MJD(TT) using FITS timing keywords
+- Handles both event lists and light curves (with bin-centering)
+- Supports GTI loading and filtering
+- Robust energy column detection
+
+**Arguments:**
+- `path::AbstractString`: FITS file path
+
+**Keyword Arguments:**
+- `hdu::Int = 2`: HDU index for event data
+- `T::Type = Float64`: Data type for arrays
+- `sort::Bool = false`: Sort events by time
+- `extra_columns::Vector{String} = []`: Additional columns to read
+- `energy_alternatives::Vector{String} = ["ENERGY", "PI", "PHA"]`: Energy column names
+- `load_gti::Bool = true`: Load GTI information
+- `apply_gti_filter::Bool = false`: Filter events using GTI
+
+**Timing Conversions:**
+- **Event data**: `MJD(TT) = (MJDREF+MJDREFF)+(TIME+TIMEZERO)/86400`
+- **Light curve data**: Includes bin-centering: `+(0.5-TIMEPIXR)*TIMEDEL`
+
+**Example:**
 ```julia
-# Basic usage with GTI loading
-ev = readevents("events.fits")
+# Basic usage
+events = readevents("ni1200120104_0mpu7_cl.evt", load_gti=true, sort=true)
+println("Time range: $(extrema(times(events)))")  # MJD values
 
-# With GTI filtering applied automatically
-ev = readevents("events.fits", apply_gti_filter=true)
+# With GTI filtering
+filtered_events = readevents("events.fits", apply_gti_filter=true)
 
-# Custom GTI HDU specification
-ev = readevents("events.fits", gti_hdu_candidates=["MYGTI"], gti_hdu_indices=[4])
+# Light curve with automatic bin-centering
+lightcurve = readevents("lightcurve.fits")
+```
 
-# With custom options
-ev = readevents("events.fits", hdu=3, sort=true, T=Float32, load_gti=false)
+## Accessor Functions
 
-# Reading extra columns with GTI
-ev = readevents("events.fits", extra_columns=["RAWX", "RAWY"], apply_gti_filter=true)
+### `times(ev::EventList)`
+Returns the time vector from an EventList.
 
-# Accessing the data and GTI
-println("Number of events: \$(length(ev))")
-println("Time range: \$(extrema(times(ev)))")
-if has_gti(ev)
-    println("GTI exposure: \$(gti_exposure(ev)) seconds")
-    gti_info(ev)
+### `energies(ev::EventList)`
+Returns the energy vector (or `nothing` if no energies).
+
+### `has_energies(ev::EventList) -> Bool`
+Check if energy data is present.
+
+### `has_gti(ev::EventList) -> Bool`
+Check if GTI data is available.
+
+### `gti(ev::EventList) -> Union{Nothing, Matrix{Float64}}`
+Get GTI matrix (2×N with START/STOP times).
+
+### `gti_exposure(ev::EventList) -> Float64`
+Calculate total exposure time from GTI or time span.
+
+### `gti_info(ev::EventList)`
+Display GTI information summary.
+
+## Filtering Functions
+
+### In-place Filtering
+- `filter_time!(predicate, ev)`: Filter by time condition
+- `filter_energy!(predicate, ev)`: Filter by energy condition
+
+### Non-mutating Filtering
+- `filter_time(predicate, ev)`: Return filtered copy by time
+- `filter_energy(predicate, ev)`: Return filtered copy by energy
+
+**Example:**
+```julia
+# Filter events above 2 keV
+high_energy = filter_energy(e -> e > 2.0, events)
+
+# Filter time range (in-place)
+filter_time!(t -> t > 58192.1, events)
+
+# Chain filters
+result = filter_energy(e -> e < 10.0, filter_time(t -> t > 58192.0, events))
+```
+
+## Utility Functions
+
+### `extract_timing_keywords(header)`
+Extract timing parameters from FITS header.
+
+**Returns:** `(mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del)`
+
+### `read_energy_column(hdu; energy_alternatives, T)`
+Robust energy column reading with fallback options.
+
+### `read_gti_from_fits(fits_file; gti_hdu_candidates, gti_hdu_indices)`
+Read GTI data from FITS file using multiple search strategies.
+
+### `colnames(file; hdu=2)`
+Get column names from FITS HDU.
+
+**Example:**
+```julia
+# Check available columns
+cols = colnames("events.fits")
+println("Available columns: $cols")
+```
+
+## Timing Standards
+
+This implementation follows RXTE timing conventions:
+
+1. **Raw times** are mission elapsed time (MET) in seconds since epoch
+2. **TIMEZERO** provides clock corrections (typically sub-second)
+3. **MJDREF** gives the mission reference epoch in MJD
+4. **Final times** are in MJD(TT) - Modified Julian Date in Terrestrial Time
+
+### Time Systems
+- **TT (Terrestrial Time)**: Standard for X-ray timing analysis
+- **MJD**: Modified Julian Date (JD - 2400000.5)
+- **Event times**: Start of time bin (TIMEPIXR = 0.0)
+- **Light curve times**: Bin-centered for proper analysis
+
+## GTI (Good Time Interval) Support
+
+GTIs define periods when the detector was operating properly:
+
+- Automatically loaded from "GTI" or "STDGTI" HDUs
+- Support for multiple GTI sources with merging
+- Optional automatic event filtering
+- Exposure time calculations
+
+**Example:**
+```julia
+if has_gti(events)
+    println("GTI exposure: $(gti_exposure(events)) seconds")
+    gti_info(events)
 end
 ```
-# GTI Behavior
-- GTI data is automatically searched for in common HDU names ("GTI", "STDGTI")
-- If `apply_gti_filter=true`, events outside GTI intervals are automatically removed
-- GTI information is stored in the metadata for later use
-- Auto-detection searches for HDUs containing "START" and "STOP" columns
 
-# Error Handling
-- Throws `AssertionError` if time and energy vectors have different sizes
-- Throws `AssertionError` if times are not sorted and `sort=false`
-- GTI reading errors are logged as debug messages and don't fail the main read
-- FITS reading errors are propagated from the FITSIO.jl library
+## Error Handling
 
-# Implementation Notes
-- Uses type-stable FITS reading with explicit type conversions
-- Handles missing energy data gracefully
-- Supports efficient multi-column sorting when `sort=true`
-- Creates metadata with all relevant file information including GTI
-- Validates data consistency before returning
-- Uses case_sensitive=false parameter for backward compatibility
+- **Data validation**: Time/energy array size matching
+- **Sorting requirements**: Events must be time-ordered
+- **GTI errors**: Logged but don't fail the read operation
+- **Missing columns**: Graceful handling with warnings
+
+## Performance Notes
+
+- Type-stable operations for efficiency
+- In-place filtering to minimize memory allocation
+- Efficient sorting with `sortperm` when needed
+- Lazy GTI loading (only when requested)
+
+## Integration with Analysis Tools
+
+The timing corrections ensure compatibility with:
+- Stingray (Python X-ray timing package)
+- XRONOS timing analysis
+- Cross-spectrum and power spectrum analysis
+- Barycentric correction tools (like `barycorr`)
+
+Times are ready for direct use in timing analysis without additional corrections.
 """
 function readevents(
     path::AbstractString;
@@ -952,6 +1079,37 @@ function readevents(
         mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del = extract_timing_keywords(header)
 
         (time, energy, energy_column, header, extra_data, mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del)
+    end
+
+    # Calculate absolute MJD(TT) times if timing keywords are available
+    if !isnothing(mjd_ref)
+        effective_timezero = isnothing(time_zero) ? 0.0 : time_zero
+
+        
+        # Check if this is binned data (light curve) vs event data
+        is_binned_data = !isnothing(time_del) && time_del > 0.0
+        
+        if is_binned_data
+            # For light curve data - apply bin-centering correction
+            # MJD(TT) = (MJDREF+MJDREFF)+(TIME+TIMEZERO+FINECLOCK+(0.5-TIMEPIXR)*TIMEDEL)/86400
+            effective_timepixr = isnothing(time_pixr) ? 0.0 : time_pixr
+            bin_center_correction = (0.5 - effective_timepixr) * time_del
+            
+            corrected_time = time .+ effective_timezero .+ bin_center_correction
+            mjd_tt_times = mjd_ref .+ (corrected_time ./ 86400.0)
+            
+            @debug "Converted to MJD(TT) with bin-centering" mjd_ref=mjd_ref time_zero=effective_timezero timedel=time_del timepixr=effective_timepixr bin_correction=bin_center_correction
+        else
+            # For event data - standard conversion
+            # MJD(TT) = (MJDREF+MJDREFF)+(TIME+TIMEZERO+FINECLOCK)/86400
+            corrected_time = time .+ effective_timezero
+            mjd_tt_times = mjd_ref .+ (corrected_time ./ 86400.0)
+            
+            @debug "Converted to MJD(TT) for event data" mjd_ref=mjd_ref time_zero=effective_timezero
+        end
+        
+        time = convert(Vector{T}, mjd_tt_times)
+        @debug "Final time range" time_range=(minimum(time), maximum(time))
     end
 
     # Validate data consistency

--- a/src/events.jl
+++ b/src/events.jl
@@ -876,14 +876,14 @@ Metadata container for FITS file information and timing parameters.
 **Example:**
 ```julia
 # Basic usage
-events = readevents("ni1200120104_0mpu7_cl.evt", load_gti=true, sort=true)
-println("Time range: $(extrema(times(events)))")  # MJD values
+evt = readevents("ni1200120104_0mpu7_cl.evt", load_gti=true, sort=true)
+println("Time range: \$(extrema(times(evt)))")  # MJD values
 
 # With GTI filtering
-filtered_events = readevents("events.fits", apply_gti_filter=true)
+filtered_evt = readevents("events.fits", apply_gti_filter=true)
 
 # Light curve with automatic bin-centering
-lightcurve = readevents("lightcurve.fits")
+lc = readevents("lightcurve.fits")
 ```
 
 ## Accessor Functions
@@ -922,13 +922,13 @@ Display GTI information summary.
 **Example:**
 ```julia
 # Filter events above 2 keV
-high_energy = filter_energy(e -> e > 2.0, events)
+high_energy = filter_energy(e -> e > 2.0, evt)
 
 # Filter time range (in-place)
-filter_time!(t -> t > 58192.1, events)
+filter_time!(t -> t > 58192.1, evt)
 
 # Chain filters
-result = filter_energy(e -> e < 10.0, filter_time(t -> t > 58192.0, events))
+result = filter_energy(e -> e < 10.0, filter_time(t -> t > 58192.0, evt))
 ```
 
 ## Utility Functions
@@ -951,7 +951,7 @@ Get column names from FITS HDU.
 ```julia
 # Check available columns
 cols = colnames("events.fits")
-println("Available columns: $cols")
+println("Available columns: \$cols")
 ```
 
 ## Timing Standards
@@ -980,9 +980,9 @@ GTIs define periods when the detector was operating properly:
 
 **Example:**
 ```julia
-if has_gti(events)
-    println("GTI exposure: $(gti_exposure(events)) seconds")
-    gti_info(events)
+if has_gti(evt)
+    println("GTI exposure: \$(gti_exposure(evt)) seconds")
+    gti_info(evt)
 end
 ```
 
@@ -1085,7 +1085,6 @@ function readevents(
     if !isnothing(mjd_ref)
         effective_timezero = isnothing(time_zero) ? 0.0 : time_zero
 
-        
         # Check if this is binned data (light curve) vs event data
         is_binned_data = !isnothing(time_del) && time_del > 0.0
         
@@ -1152,7 +1151,6 @@ function readevents(
                        mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del)
     return EventList(time, energy, meta)
 end
-
 # ============================================================================
 # Utility Functions
 # ============================================================================

--- a/src/events.jl
+++ b/src/events.jl
@@ -812,6 +812,25 @@ function extract_timing_keywords(header)
     return mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del
 end
 """
+    sec_to_mjd(t_sec, mjdref)
+
+Convert time in seconds to Modified Julian Date (MJD).
+
+# Arguments
+- `t_sec`: Time in seconds (can be scalar or vector)
+- `mjdref`: MJD reference time
+
+# Returns
+- Time in MJD format
+
+This function is useful for comparing times from different instruments while
+maintaining precision. Note that for microsecond precision, float64 may be
+at its limits for recent MJD values.
+"""
+function sec_to_mjd(t_sec, mjdref)
+    return t_sec / 86400.0 .+ mjdref
+end
+"""
     readevents(path; kwargs...)
 
 ## Overview
@@ -1022,6 +1041,7 @@ function readevents(
     gti_hdu_indices::Union{Vector{Int}, Nothing} = nothing,
     combine_gtis::Bool = true,
     apply_gti_filter::Bool = false,
+    convert_to_mjd::Bool = false,  # New parameter to control MJD conversion
     kwargs...,
 )::EventList{Vector{T},FITSMetadata{FITSIO.FITSHeader}}
 
@@ -1081,33 +1101,32 @@ function readevents(
         (time, energy, energy_column, header, extra_data, mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del)
     end
 
-    # Calculate absolute MJD(TT) times if timing keywords are available
+    # Apply time corrections and optionally convert to MJD
     if !isnothing(mjd_ref)
         effective_timezero = isnothing(time_zero) ? 0.0 : time_zero
 
-        # Check if this is binned data (light curve) vs event data
-        is_binned_data = !isnothing(time_del) && time_del > 0.0
-        
-        if is_binned_data
-            # For light curve data - apply bin-centering correction
-            # MJD(TT) = (MJDREF+MJDREFF)+(TIME+TIMEZERO+FINECLOCK+(0.5-TIMEPIXR)*TIMEDEL)/86400
+        # Apply bin-centering correction if TIMEDEL and TIMEPIXR are available
+        # This applies to both binned data and event data with limited resolution
+        if !isnothing(time_del) && time_del > 0.0
             effective_timepixr = isnothing(time_pixr) ? 0.0 : time_pixr
             bin_center_correction = (0.5 - effective_timepixr) * time_del
             
             corrected_time = time .+ effective_timezero .+ bin_center_correction
-            mjd_tt_times = mjd_ref .+ (corrected_time ./ 86400.0)
-            
-            @debug "Converted to MJD(TT) with bin-centering" mjd_ref=mjd_ref time_zero=effective_timezero timedel=time_del timepixr=effective_timepixr bin_correction=bin_center_correction
+            @debug "Applied bin-centering correction" time_zero=effective_timezero timedel=time_del timepixr=effective_timepixr bin_correction=bin_center_correction
         else
-            # For event data - standard conversion
-            # MJD(TT) = (MJDREF+MJDREFF)+(TIME+TIMEZERO+FINECLOCK)/86400
             corrected_time = time .+ effective_timezero
-            mjd_tt_times = mjd_ref .+ (corrected_time ./ 86400.0)
-            
-            @debug "Converted to MJD(TT) for event data" mjd_ref=mjd_ref time_zero=effective_timezero
+            @debug "Applied time zero correction" time_zero=effective_timezero
         end
         
-        time = convert(Vector{T}, mjd_tt_times)
+        # Convert to MJD only if requested
+        if convert_to_mjd
+            time = convert(Vector{T}, sec_to_mjd(corrected_time, mjd_ref))
+            @debug "Converted to MJD(TT)" mjd_ref=mjd_ref
+        else
+            time = convert(Vector{T}, corrected_time)
+            @debug "Kept times in seconds (corrected)" 
+        end
+        
         @debug "Final time range" time_range=(minimum(time), maximum(time))
     end
 

--- a/test/test_events.jl
+++ b/test/test_events.jl
@@ -20,7 +20,6 @@ function mock_data(times, energies; energy_column = "ENERGY")
     end
     sample_file
 end
-
 # Test basic EventList creation and validation
 let
     # Test valid construction with simplified constructor
@@ -115,7 +114,13 @@ let
         Dict("INDEX" => [1, 2, 3, 4]), # extra_columns
         Dict{String,Any}(),         # headers
         nothing,                    # gti
-        nothing                     # gti_source
+        nothing,                    # gti_source
+        nothing,                    # mjd_ref
+        nothing,                    # time_zero
+        nothing,                    # time_unit
+        nothing,                    # time_sys
+        nothing,                    # time_pixr
+        nothing                     # time_del
     )
     ev_extra = EventList(times_extra, energies_extra, dummy_meta)
 
@@ -160,7 +165,13 @@ let
         Dict("DETX" => [0.1, 0.2, 0.3, 0.4]), # extra_columns
         Dict{String,Any}(),           # headers
         nothing,                      # gti
-        nothing                       # gti_source
+        nothing,                      # gti_source
+        nothing,                      # mjd_ref
+        nothing,                      # time_zero
+        nothing,                      # time_unit
+        nothing,                      # time_sys
+        nothing,                      # time_pixr
+        nothing                       # time_del
     )
     ev_extra = EventList(times_extra, energies_extra, dummy_meta)
 
@@ -204,13 +215,19 @@ let
     times_extra = [1.0, 2.0, 3.0, 4.0, 5.0]
     energies_extra = [10.0, 20.0, 30.0, 40.0, 50.0]
     dummy_meta = FITSMetadata{Dict{String,Any}}(
-        "",                           # filepath
-        1,                           # hdu
-        nothing,                     # energy_units
+        "",                            # filepath
+        1,                            # hdu
+        nothing,                      # energy_units
         Dict("FLAG" => [1, 0, 1, 0, 1]), # extra_columns
-        Dict{String,Any}(),          # headers
-        nothing,                     # gti
-        nothing                      # gti_source
+        Dict{String,Any}(),           # headers
+        nothing,                      # gti
+        nothing,                      # gti_source
+        nothing,                      # mjd_ref
+        nothing,                      # time_zero
+        nothing,                      # time_unit
+        nothing,                      # time_sys
+        nothing,                      # time_pixr
+        nothing                       # time_del
     )
     ev_extra = EventList(times_extra, energies_extra, dummy_meta)
 
@@ -461,7 +478,13 @@ let
         Dict{String,Vector}(),         # extra_columns
         Dict{String,Any}(),            # headers
         gti_matrix,                    # gti
-        "GTI"                          # gti_source
+        "GTI",                         # gti_source
+        nothing,                       # mjd_ref
+        nothing,                       # time_zero
+        nothing,                       # time_unit
+        nothing,                       # time_sys
+        nothing,                       # time_pixr
+        nothing                        # time_del
     )
     ev_with_gti = EventList(times, energies, meta_with_gti)
     
@@ -478,13 +501,19 @@ let
     # Test exposure calculation with GTI
     gti_matrix = [1.0 3.0; 4.0 6.0; 8.0 10.0]  # Intervals: 2s + 2s + 2s = 6s total
     meta_with_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits",
-        2,
-        "ENERGY",
-        Dict{String,Vector}(),
-        Dict{String,Any}(),
-        gti_matrix,
-        "GTI"
+        "test.fits",                    # filepath
+        2,                             # hdu
+        "ENERGY",                      # energy_units
+        Dict{String,Vector}(),         # extra_columns
+        Dict{String,Any}(),            # headers
+        gti_matrix,                    # gti
+        "GTI",                         # gti_source
+        nothing,                       # mjd_ref
+        nothing,                       # time_zero
+        nothing,                       # time_unit
+        nothing,                       # time_sys
+        nothing,                       # time_pixr
+        nothing                        # time_del
     )
     ev_with_gti = EventList(times, energies, meta_with_gti)
     
@@ -502,8 +531,19 @@ let
     # Test single interval GTI
     single_gti = reshape([2.0, 5.0], 1, 2)  # One interval: [2.0, 5.0] = 3s
     meta_single_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, "ENERGY", Dict{String,Vector}(), Dict{String,Any}(),
-        single_gti, "GTI"
+        "test.fits",                   # filepath
+        2,                            # hdu
+        "ENERGY",                     # energy_units
+        Dict{String,Vector}(),        # extra_columns
+        Dict{String,Any}(),           # headers
+        single_gti,                   # gti
+        "GTI",                        # gti_source
+        nothing,                      # mjd_ref
+        nothing,                      # time_zero
+        nothing,                      # time_unit
+        nothing,                      # time_sys
+        nothing,                      # time_pixr
+        nothing                       # time_del
     )
     ev_single_gti = EventList(times, energies, meta_single_gti)
     @test gti_exposure(ev_single_gti) == 3.0
@@ -518,8 +558,19 @@ let
     # Test gti_info with GTI present
     gti_matrix = [1.0 2.5; 3.0 4.0]
     meta_with_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, "ENERGY", Dict{String,Vector}(), Dict{String,Any}(),
-        gti_matrix, "GTI"
+        "test.fits",                    # filepath
+        2,                             # hdu
+        "ENERGY",                      # energy_units
+        Dict{String,Vector}(),         # extra_columns
+        Dict{String,Any}(),            # headers
+        gti_matrix,                    # gti
+        "GTI",                         # gti_source
+        nothing,                       # mjd_ref
+        nothing,                       # time_zero
+        nothing,                       # time_unit
+        nothing,                       # time_sys
+        nothing,                       # time_pixr
+        nothing                        # time_del
     )
     ev_with_gti = EventList(times, energies, meta_with_gti)
     
@@ -539,10 +590,21 @@ let
     gti_matrix = [1.0 3.0; 5.0 7.0]  # Two 2-second intervals
     extra_cols = Dict("INDEX" => [1, 2, 3])
     meta_with_gti = FITSMetadata{Dict{String,Any}}(
-        "/path/to/test.fits", 2, "ENERGY", extra_cols, Dict{String,Any}(),
-        gti_matrix, "GTI"
+        "/path/to/test.fits",          # filepath
+        2,                             # hdu
+        "ENERGY",                      # energy_units
+        extra_cols,                    # extra_columns
+        Dict{String,Any}(),            # headers
+        gti_matrix,                    # gti
+        "GTI",                         # gti_source
+        nothing,                       # mjd_ref
+        nothing,                       # time_zero
+        nothing,                       # time_unit
+        nothing,                       # time_sys
+        nothing,                       # time_pixr
+        nothing                        # time_del
     )
-    
+        
     # Test that show method includes GTI information
     io = IOBuffer()
     show(io, MIME("text/plain"), meta_with_gti)
@@ -555,8 +617,19 @@ let
     
     # Test display without GTI
     meta_no_gti = FITSMetadata{Dict{String,Any}}(
-        "/path/to/test.fits", 2, "ENERGY", extra_cols, Dict{String,Any}(),
-        nothing, nothing
+        "/path/to/test.fits",          # filepath
+        2,                             # hdu
+        "ENERGY",                      # energy_units
+        extra_cols,                    # extra_columns
+        Dict{String,Any}(),            # headers
+        nothing,                       # gti
+        nothing,                       # gti_source
+        nothing,                       # mjd_ref
+        nothing,                       # time_zero
+        nothing,                       # time_unit
+        nothing,                       # time_sys
+        nothing,                       # time_pixr
+        nothing                        # time_del
     )
     
     io2 = IOBuffer()
@@ -568,7 +641,6 @@ let
     @test !occursin("GTI:", output2)  # Should not mention GTI
     
 end
-
 # Test Base.summary with GTI information
 let
     times = [1.0, 2.0, 3.0, 4.0]
@@ -577,8 +649,19 @@ let
     # Test summary with GTI
     gti_matrix = [1.0 2.0; 3.0 5.0]  # 1s + 2s = 3s total exposure
     meta_with_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, "keV", Dict("FLAG" => [1, 0, 1, 0]), Dict{String,Any}(),
-        gti_matrix, "GTI"
+        "test.fits",                    # filepath
+        2,                             # hdu
+        "ENERGY",                      # energy_units
+        Dict{String,Vector}(),         # extra_columns
+        Dict{String,Any}(),            # headers
+        gti_matrix,                    # gti
+        "GTI",                         # gti_source
+        nothing,                       # mjd_ref
+        nothing,                       # time_zero
+        nothing,                       # time_unit
+        nothing,                       # time_sys
+        nothing,                       # time_pixr
+        nothing                        # time_del
     )
     ev_with_gti = EventList(times, energies, meta_with_gti)
     
@@ -598,8 +681,19 @@ let
     
     # Test summary without energies but with GTI
     meta_time_only_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, nothing, Dict{String,Vector}(), Dict{String,Any}(),
-        gti_matrix, "GTI"
+        "test.fits",                   # filepath
+        2,                            # hdu
+        nothing,                      # energy_units
+        Dict{String,Vector}(),        # extra_columns
+        Dict{String,Any}(),           # headers
+        gti_matrix,                   # gti
+        "GTI",                        # gti_source
+        nothing,                      # mjd_ref
+        nothing,                      # time_zero
+        nothing,                      # time_unit
+        nothing,                      # time_sys
+        nothing,                      # time_pixr
+        nothing                       # time_del
     )
     ev_time_only_gti = EventList(times, nothing, meta_time_only_gti)
     
@@ -619,8 +713,19 @@ let
     gti_matrix = [1.0 2.5; 3.0 5.0]
     extra_cols = Dict("INDEX" => collect(1:7))
     meta_with_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, "ENERGY", extra_cols, Dict{String,Any}(),
-        gti_matrix, "GTI"
+        "test.fits",                    # filepath
+        2,                             # hdu
+        "ENERGY",                      # energy_units
+        extra_cols,                    # extra_columns
+        Dict{String,Any}(),            # headers
+        gti_matrix,                    # gti
+        "GTI",                         # gti_source
+        nothing,                       # mjd_ref
+        nothing,                       # time_zero
+        nothing,                       # time_unit
+        nothing,                       # time_sys
+        nothing,                       # time_pixr
+        nothing                        # time_del
     )
     ev_with_gti = EventList(times, energies, meta_with_gti)
     
@@ -662,8 +767,19 @@ let
     # Test with empty GTI matrix
     empty_gti = Matrix{Float64}(undef, 0, 2)
     meta_empty_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, "ENERGY", Dict{String,Vector}(), Dict{String,Any}(),
-        empty_gti, "GTI"
+        "test.fits",                   # filepath
+        2,                            # hdu
+        "ENERGY",                     # energy_units
+        Dict{String,Vector}(),        # extra_columns
+        Dict{String,Any}(),           # headers
+        empty_gti,                    # gti
+        "GTI",                        # gti_source
+        nothing,                      # mjd_ref
+        nothing,                      # time_zero
+        nothing,                      # time_unit
+        nothing,                      # time_sys
+        nothing,                      # time_pixr
+        nothing                       # time_del
     )
     ev_empty_gti = EventList(times, energies, meta_empty_gti)
     @test has_gti(ev_empty_gti)
@@ -672,8 +788,19 @@ let
     # Test with single point GTI intervals (start == stop)
     point_gti = [2.0 2.0; 3.0 3.0]  # Zero-duration intervals
     meta_point_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, "ENERGY", Dict{String,Vector}(), Dict{String,Any}(),
-        point_gti, "GTI"
+        "test.fits",                   # filepath
+        2,                            # hdu
+        "ENERGY",                     # energy_units
+        Dict{String,Vector}(),        # extra_columns
+        Dict{String,Any}(),           # headers
+        point_gti,                    # gti
+        "GTI",                        # gti_source
+        nothing,                      # mjd_ref
+        nothing,                      # time_zero
+        nothing,                      # time_unit
+        nothing,                      # time_sys
+        nothing,                      # time_pixr
+        nothing                       # time_del
     )
     ev_point_gti = EventList(times, energies, meta_point_gti)
     @test has_gti(ev_point_gti)
@@ -682,8 +809,19 @@ let
     # Test with very large GTI values
     large_gti = [1e6 2e6; 3e6 4e6]  # Large time values
     meta_large_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, "ENERGY", Dict{String,Vector}(), Dict{String,Any}(),
-        large_gti, "GTI"
+        "test.fits",                   # filepath
+        2,                            # hdu
+        "ENERGY",                     # energy_units
+        Dict{String,Vector}(),        # extra_columns
+        Dict{String,Any}(),           # headers
+        large_gti,                    # gti
+        "GTI",                        # gti_source
+        nothing,                      # mjd_ref
+        nothing,                      # time_zero
+        nothing,                      # time_unit
+        nothing,                      # time_sys
+        nothing,                      # time_pixr
+        nothing                       # time_del
     )
     ev_large_gti = EventList(times, energies, meta_large_gti)
     @test has_gti(ev_large_gti)
@@ -698,8 +836,19 @@ let
     
     gti_matrix = [1.0 2.5; 3.0 4.0]
     meta_with_gti = FITSMetadata{Dict{String,Any}}(
-        "test.fits", 2, "ENERGY", Dict{String,Vector}(), Dict{String,Any}(),
-        gti_matrix, "GTI"
+        "test.fits",                    # filepath
+        2,                             # hdu
+        "ENERGY",                      # energy_units
+        Dict{String,Vector}(),         # extra_columns
+        Dict{String,Any}(),            # headers
+        gti_matrix,                    # gti
+        "GTI",                         # gti_source
+        nothing,                       # mjd_ref
+        nothing,                       # time_zero
+        nothing,                       # time_unit
+        nothing,                       # time_sys
+        nothing,                       # time_pixr
+        nothing                        # time_del
     )
     ev_with_gti = EventList(times, energies, meta_with_gti)
     
@@ -709,4 +858,48 @@ let
     # Test without GTI (still warns)
     ev_no_gti = EventList(times, energies)
     @test_logs (:warn, "No GTI information available") gti_info(ev_no_gti)
+end
+# Test timing keywords extraction with dummy data
+let
+    # Create mock FITS header with timing keywords
+    mock_header = Dict{String,Any}(
+        "MJDREFI" => 56658,
+        "MJDREFF" => 0.00077759259,
+        "TIMEZERO" => -1.0,
+        "TIMEUNIT" => "s",
+        "TIMESYS" => "TT",
+        "TIMEPIXR" => 0.0,
+        "TIMEDEL" => 4.0e-8
+    )
+    
+    # Test the extract_timing_keywords function directly
+    mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del = extract_timing_keywords(mock_header)
+    
+    # Test that MJDREF is correctly calculated from MJDREFI + MJDREFF
+    @test mjd_ref ≈ (mock_header["MJDREFI"] + mock_header["MJDREFF"])
+    
+    # Test that values are extracted correctly from header
+    @test time_zero == mock_header["TIMEZERO"]
+    @test time_sys == mock_header["TIMESYS"]
+    @test time_pixr == mock_header["TIMEPIXR"]
+    @test time_del == mock_header["TIMEDEL"]
+    
+    # Test time unit conversion from string "s" to 1.0
+    @test time_unit == 1.0
+    
+    # Test different time unit conversions
+    @test extract_timing_keywords(Dict("TIMEUNIT" => "s"))[3] == 1.0
+    @test extract_timing_keywords(Dict("TIMEUNIT" => "d"))[3] == 86400.0
+    @test extract_timing_keywords(Dict("TIMEUNIT" => "ms"))[3] == 0.001
+    @test extract_timing_keywords(Dict("TIMEUNIT" => "1.5"))[3] == 1.5
+    
+    # Test missing keywords return nothing
+    empty_header = Dict{String,Any}()
+    mjd_empty, time_zero_empty, time_unit_empty, time_sys_empty, time_pixr_empty, time_del_empty = extract_timing_keywords(empty_header)
+    @test isnothing(mjd_empty)
+    @test isnothing(time_zero_empty)
+    @test isnothing(time_unit_empty)
+    @test isnothing(time_sys_empty)
+    @test isnothing(time_pixr_empty)
+    @test isnothing(time_del_empty)
 end

--- a/test/test_events.jl
+++ b/test/test_events.jl
@@ -946,36 +946,31 @@ end
 
 # Test MJD(TT) calculation for event data
 let
-    # Mock event data (raw mission elapsed time)
     raw_times = [100000.0, 100001.0, 100002.0]
     mjd_ref = 56658.00077759259
     time_zero = -1.0
     
-    # Expected calculation: mjd_ref + (raw_times + time_zero) / 86400
     expected_times = mjd_ref .+ ((raw_times .+ time_zero) ./ 86400.0)
     
-    # Test the calculation matches expected formula
     corrected_times = raw_times .+ time_zero
     mjd_tt_times = mjd_ref .+ (corrected_times ./ 86400.0)
     
     @test mjd_tt_times ≈ expected_times
-    @test all(mjd_tt_times .> 56000)  # Should be proper MJD values
-    @test maximum(mjd_tt_times) - minimum(mjd_tt_times) ≈ 2.0/86400.0 atol=1e-10  # 2 second span
+    @test all(mjd_tt_times .> 56000)
+    @test maximum(mjd_tt_times) - minimum(mjd_tt_times) ≈ 2.0/86400.0 atol=1e-10
 end
-# Test MJD(TT) calculation for light curve data (bin-centering)
+
+# Test bin-centering correction for light curve data
 let
-    # Mock light curve data
-    raw_times = [0.0, 1.0, 2.0]  # Bin start times
+    raw_times = [0.0, 1.0, 2.0]
     mjd_ref = 56658.0
     time_zero = 0.0
-    time_del = 1.0      # 1 second bins
-    time_pixr = 0.0     # Standard for RXTE
+    time_del = 1.0
+    time_pixr = 0.0
     
-    # Bin-centering correction: (0.5 - TIMEPIXR) * TIMEDEL
     bin_center_correction = (0.5 - time_pixr) * time_del
-    @test bin_center_correction ≈ 0.5  # Should center bins
+    @test bin_center_correction ≈ 0.5
     
-    # Expected: times should be centered on bin midpoints
     expected_corrected = raw_times .+ time_zero .+ bin_center_correction
     expected_mjd = mjd_ref .+ (expected_corrected ./ 86400.0)
     
@@ -983,92 +978,16 @@ let
     mjd_tt_times = mjd_ref .+ (corrected_times ./ 86400.0)
     
     @test mjd_tt_times ≈ expected_mjd
-    # First bin should be centered at 0.5 seconds, not 0.0
     @test mjd_tt_times[1] ≈ mjd_ref + 0.5/86400.0
 end
 
-# Test data type detection (event vs binned)
+# Test data type detection
 let
-    # Event data: no TIMEDEL or TIMEDEL = 0
-    @test isnothing(nothing) || (0.0 <= 0.0)  # Event data condition
-    
-    # Binned data: TIMEDEL > 0
     time_del_binned = 0.1
     is_binned = !isnothing(time_del_binned) && time_del_binned > 0.0
     @test is_binned == true
     
-    # Event data: TIMEDEL missing
     time_del_event = nothing
     is_binned_event = !isnothing(time_del_event) && time_del_event > 0.0
     @test is_binned_event == false
-end
-
-# Test time range validation
-let
-    # Test typical NICER observation time ranges
-    mjd_ref = 56658.00077759259  # NICER reference epoch
-    observation_duration = 3600.0  # 1 hour observation
-    raw_start_time = 133000000.0  # ~4.2 years after epoch
-    
-    time_zero = -1.0
-    raw_times = [raw_start_time, raw_start_time + observation_duration]
-    
-    corrected_times = raw_times .+ time_zero
-    mjd_tt_times = mjd_ref .+ (corrected_times ./ 86400.0)
-    
-    # Should produce reasonable MJD values (around 58000 for 2018)
-    @test all(mjd_tt_times .> 58000)
-    @test all(mjd_tt_times .< 60000)
-    
-    # Duration should be preserved in MJD units
-    duration_mjd = (mjd_tt_times[2] - mjd_tt_times[1]) * 86400.0
-    @test duration_mjd ≈ observation_duration atol=1e-6
-end
-
-# Test safe_float64 helper function behavior
-let
-    # Test string unit parsing
-    @test extract_timing_keywords(Dict("TIMEUNIT" => "s"))[3] ≈ 1.0
-    @test extract_timing_keywords(Dict("TIMEUNIT" => "d"))[3] ≈ 86400.0
-    @test extract_timing_keywords(Dict("TIMEUNIT" => "ms"))[3] ≈ 0.001
-    
-    # Test numeric parsing
-    @test extract_timing_keywords(Dict("TIMEZERO" => "123.45"))[2] ≈ 123.45
-    @test extract_timing_keywords(Dict("TIMEZERO" => 67.89))[2] ≈ 67.89
-    
-    # Test invalid string handling
-    result = extract_timing_keywords(Dict("TIMEZERO" => "invalid"))
-    @test isnothing(result[2])
-end
-
-# Test complete timing workflow
-let
-    # Simulate complete timing calculation workflow
-    mjd_ref = 56658.00077759259
-    time_zero = -1.0
-    time_del = nothing  # Event data
-    time_pixr = 0.0
-    
-    # Raw event times (seconds since epoch)
-    raw_times = [133000000.0, 133000001.5, 133000003.2]
-    
-    # Apply corrections
-    effective_timezero = isnothing(time_zero) ? 0.0 : time_zero
-    is_binned_data = !isnothing(time_del) && time_del > 0.0
-    
-    @test is_binned_data == false  # Should detect as event data
-    
-    # Calculate MJD(TT)
-    corrected_time = raw_times .+ effective_timezero
-    mjd_tt_times = mjd_ref .+ (corrected_time ./ 86400.0)
-    
-    # Validate results
-    @test length(mjd_tt_times) == 3
-    @test all(mjd_tt_times .> mjd_ref)  # Should be after reference epoch
-    @test issorted(mjd_tt_times)        # Should maintain time order
-    
-    # Check that relative timing is preserved
-    dt1 = (raw_times[2] - raw_times[1])
-    dt2 = (mjd_tt_times[2] - mjd_tt_times[1]) * 86400.0
-    @test dt1 ≈ dt2 atol=1e-6
 end

--- a/test/test_events.jl
+++ b/test/test_events.jl
@@ -903,3 +903,172 @@ let
     @test isnothing(time_pixr_empty)
     @test isnothing(time_del_empty)
 end
+# Test timing keyword extraction
+let
+    # Test basic MJDREF extraction
+    header1 = Dict("MJDREF" => 49353.000696574074)
+    mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del = extract_timing_keywords(header1)
+    @test mjd_ref ≈ 49353.000696574074
+    @test isnothing(time_zero)
+    @test isnothing(time_unit)
+    @test isnothing(time_sys)
+    @test isnothing(time_pixr)
+    @test isnothing(time_del)
+
+    # Test MJDREFI + MJDREFF combination
+    header2 = Dict("MJDREFI" => 49353, "MJDREFF" => 0.000696574074)
+    mjd_ref, _, _, _, _, _ = extract_timing_keywords(header2)
+    @test mjd_ref ≈ 49353.000696574074
+
+    # Test all timing keywords
+    header3 = Dict(
+        "MJDREF" => 56658.00077759259,
+        "TIMEZERO" => -1.0,
+        "TIMEUNIT" => "s",
+        "TIMESYS" => "TT",
+        "TIMEPIXR" => 0.0,
+        "TIMEDEL" => 0.1
+    )
+    mjd_ref, time_zero, time_unit, time_sys, time_pixr, time_del = extract_timing_keywords(header3)
+    @test mjd_ref ≈ 56658.00077759259
+    @test time_zero ≈ -1.0
+    @test time_unit ≈ 1.0  # "s" converts to 1.0
+    @test time_sys == "TT"
+    @test time_pixr ≈ 0.0
+    @test time_del ≈ 0.1
+
+    # Test string unit conversions
+    header4 = Dict("TIMEUNIT" => "d", "TIMEDEL" => "ms")
+    _, _, time_unit, _, _, time_del = extract_timing_keywords(header4)
+    @test time_unit ≈ 86400.0  # days to seconds
+    @test time_del ≈ 0.001     # milliseconds to seconds
+end
+
+# Test MJD(TT) calculation for event data
+let
+    # Mock event data (raw mission elapsed time)
+    raw_times = [100000.0, 100001.0, 100002.0]
+    mjd_ref = 56658.00077759259
+    time_zero = -1.0
+    
+    # Expected calculation: mjd_ref + (raw_times + time_zero) / 86400
+    expected_times = mjd_ref .+ ((raw_times .+ time_zero) ./ 86400.0)
+    
+    # Test the calculation matches expected formula
+    corrected_times = raw_times .+ time_zero
+    mjd_tt_times = mjd_ref .+ (corrected_times ./ 86400.0)
+    
+    @test mjd_tt_times ≈ expected_times
+    @test all(mjd_tt_times .> 56000)  # Should be proper MJD values
+    @test maximum(mjd_tt_times) - minimum(mjd_tt_times) ≈ 2.0/86400.0 atol=1e-10  # 2 second span
+end
+# Test MJD(TT) calculation for light curve data (bin-centering)
+let
+    # Mock light curve data
+    raw_times = [0.0, 1.0, 2.0]  # Bin start times
+    mjd_ref = 56658.0
+    time_zero = 0.0
+    time_del = 1.0      # 1 second bins
+    time_pixr = 0.0     # Standard for RXTE
+    
+    # Bin-centering correction: (0.5 - TIMEPIXR) * TIMEDEL
+    bin_center_correction = (0.5 - time_pixr) * time_del
+    @test bin_center_correction ≈ 0.5  # Should center bins
+    
+    # Expected: times should be centered on bin midpoints
+    expected_corrected = raw_times .+ time_zero .+ bin_center_correction
+    expected_mjd = mjd_ref .+ (expected_corrected ./ 86400.0)
+    
+    corrected_times = raw_times .+ time_zero .+ bin_center_correction
+    mjd_tt_times = mjd_ref .+ (corrected_times ./ 86400.0)
+    
+    @test mjd_tt_times ≈ expected_mjd
+    # First bin should be centered at 0.5 seconds, not 0.0
+    @test mjd_tt_times[1] ≈ mjd_ref + 0.5/86400.0
+end
+
+# Test data type detection (event vs binned)
+let
+    # Event data: no TIMEDEL or TIMEDEL = 0
+    @test isnothing(nothing) || (0.0 <= 0.0)  # Event data condition
+    
+    # Binned data: TIMEDEL > 0
+    time_del_binned = 0.1
+    is_binned = !isnothing(time_del_binned) && time_del_binned > 0.0
+    @test is_binned == true
+    
+    # Event data: TIMEDEL missing
+    time_del_event = nothing
+    is_binned_event = !isnothing(time_del_event) && time_del_event > 0.0
+    @test is_binned_event == false
+end
+
+# Test time range validation
+let
+    # Test typical NICER observation time ranges
+    mjd_ref = 56658.00077759259  # NICER reference epoch
+    observation_duration = 3600.0  # 1 hour observation
+    raw_start_time = 133000000.0  # ~4.2 years after epoch
+    
+    time_zero = -1.0
+    raw_times = [raw_start_time, raw_start_time + observation_duration]
+    
+    corrected_times = raw_times .+ time_zero
+    mjd_tt_times = mjd_ref .+ (corrected_times ./ 86400.0)
+    
+    # Should produce reasonable MJD values (around 58000 for 2018)
+    @test all(mjd_tt_times .> 58000)
+    @test all(mjd_tt_times .< 60000)
+    
+    # Duration should be preserved in MJD units
+    duration_mjd = (mjd_tt_times[2] - mjd_tt_times[1]) * 86400.0
+    @test duration_mjd ≈ observation_duration atol=1e-6
+end
+
+# Test safe_float64 helper function behavior
+let
+    # Test string unit parsing
+    @test extract_timing_keywords(Dict("TIMEUNIT" => "s"))[3] ≈ 1.0
+    @test extract_timing_keywords(Dict("TIMEUNIT" => "d"))[3] ≈ 86400.0
+    @test extract_timing_keywords(Dict("TIMEUNIT" => "ms"))[3] ≈ 0.001
+    
+    # Test numeric parsing
+    @test extract_timing_keywords(Dict("TIMEZERO" => "123.45"))[2] ≈ 123.45
+    @test extract_timing_keywords(Dict("TIMEZERO" => 67.89))[2] ≈ 67.89
+    
+    # Test invalid string handling
+    result = extract_timing_keywords(Dict("TIMEZERO" => "invalid"))
+    @test isnothing(result[2])
+end
+
+# Test complete timing workflow
+let
+    # Simulate complete timing calculation workflow
+    mjd_ref = 56658.00077759259
+    time_zero = -1.0
+    time_del = nothing  # Event data
+    time_pixr = 0.0
+    
+    # Raw event times (seconds since epoch)
+    raw_times = [133000000.0, 133000001.5, 133000003.2]
+    
+    # Apply corrections
+    effective_timezero = isnothing(time_zero) ? 0.0 : time_zero
+    is_binned_data = !isnothing(time_del) && time_del > 0.0
+    
+    @test is_binned_data == false  # Should detect as event data
+    
+    # Calculate MJD(TT)
+    corrected_time = raw_times .+ effective_timezero
+    mjd_tt_times = mjd_ref .+ (corrected_time ./ 86400.0)
+    
+    # Validate results
+    @test length(mjd_tt_times) == 3
+    @test all(mjd_tt_times .> mjd_ref)  # Should be after reference epoch
+    @test issorted(mjd_tt_times)        # Should maintain time order
+    
+    # Check that relative timing is preserved
+    dt1 = (raw_times[2] - raw_times[1])
+    dt2 = (mjd_tt_times[2] - mjd_tt_times[1]) * 86400.0
+    @test dt1 ≈ dt2 atol=1e-6
+end

--- a/test/test_gti.jl
+++ b/test/test_gti.jl
@@ -6,11 +6,16 @@ function create_test_eventlist(times::Vector{Float64}, energies::Union{Vector{Fl
         1,   # hdu
         "keV",  # energy_units
         Dict{String,Vector}(),  # extra_columns
-        mock_headers,  # headers
-        nothing,       # gti
-        nothing        # gti_source
+        mock_headers, # headers
+        nothing,      # gti
+        nothing,      # gti_source
+        nothing,      # mjd_ref
+        nothing,      # time_zero
+        nothing,      # time_unit
+        nothing,      # time_sys
+        nothing,      # time_pixr
+        nothing       # time_del
     )
-    
     return EventList(times, energies, mock_metadata)
 end
 
@@ -470,7 +475,13 @@ let
         ),
         mock_headers,  # headers
         nothing,       # gti
-        nothing        # gti_source
+        nothing,       # gti_source
+        nothing,       # mjd_ref
+        nothing,       # time_zero
+        nothing,       # time_unit
+        nothing,       # time_sys
+        nothing,       # time_pixr
+        nothing        # time_del
     )
     
     el = EventList(times, energies, mock_metadata)

--- a/test/test_lightcurve.jl
+++ b/test/test_lightcurve.jl
@@ -113,8 +113,14 @@ function create_mock_eventlist(times, energies = nothing)
         "keV",  # energy_units
         Dict{String,Vector}(),  # extra_columns
         headers,  # headers
-        nothing,       # gti
-        nothing        # gti_source
+        nothing,  # gti
+        nothing,  # gti_source
+        nothing,  # mjd_ref
+        nothing,  # time_zero
+        nothing,  # time_unit
+        nothing,  # time_sys
+        nothing,  # time_pixr
+        nothing   # time_del
     )
     
     return EventList{typeof(times),typeof(dummy_meta)}(
@@ -194,7 +200,13 @@ function create_mock_eventlist_meta(
         Dict{String,Vector}(),  # extra_columns
         test_headers,  # headers
         nothing,       # gti
-        nothing        # gti_source
+        nothing,       # gti_source
+        nothing,       # mjd_ref
+        nothing,       # time_zero
+        nothing,       # time_unit
+        nothing,       # time_sys
+        nothing,       # time_pixr
+        nothing       # time_del
     )
     
     return EventList(times, energies, meta)


### PR DESCRIPTION
## **this pr contains::**
### Extended FITSMetadata struct with timing keyword fields:


- mjd_ref: MJD reference time (supports both MJDREF and MJDREFI+MJDREFF)
- time_zero: Time zero offset (TIMEZERO)
- time_unit: Time unit conversion factor (TIMEUNIT)
- time_sys: Time system (TIMESYS)
- time_pixr: Time pixel reference (TIMEPIXR)
- time_del: Time resolution/bin size (TIMEDEL)

### Added extract_timing_keywords() function with robust keyword extraction:


- Handles string-to-numeric conversions for timing units
- Supports common time unit formats: "s", "sec", "d", "ms", etc.
- Gracefully handles missing keywords (returns nothing)
- Combines MJDREFI + MJDREFF when MJDREF not available

### Integration

- Updated readevents() function to automatically extract timing keywords
- Modified test helpers to accommodate the extended metadata structure
- Comprehensive test coverage for timing keyword extraction and validation

### Technical Details

- The implementation follows the [HEASARC timing tutorial](https://heasarc.gsfc.nasa.gov/docs/xte/abc/time_tutorial.html) specifications and handles various edge cases commonly found in X-ray astronomy FITS files.

### using 
```julia
events = readevents("ni1200120104_0mpu7_cl.evt", load_gti=true, sort=true)
println(events.meta.mjd_ref)     # Shows the MJD reference (from MJDREF or MJDREFI + MJDREFF)
println(events.meta.time_zero)   # Shows TIMEZERO
println(events.meta.time_unit)   # Shows TIMEUNIT
println(events.meta.time_sys)    # Shows TIMESYS
println(events.meta.time_pixr)   # Shows TIMEPIXR
println(events.meta.time_del)    # Shows TIMEDEL
```
output
```
56658.00077759259
-1.0
1.0
TT
0.0
4.0e-8
```