### PR TITLE
updating workflow julia version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.11'
+          - '1.12'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
This is a small change to the Julia version from `1.11` to `1.12` in the workflow patch 
I have tested this locally. This workflow looks fine to me after merging #73. We can proceed with this