### PR TITLE
Add fftfreq import to runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Stingray
 using Test
+using AbstractFFTs: fftfreq 
 using FFTW, Distributions, Statistics, StatsBase, HDF5, FITSIO
 using Logging ,LinearAlgebra
 using CFITSIO


### PR DESCRIPTION
The Fourier tests used `fftfreq` without explicitly importing the module
that defines it. With Julia ≥1.10 this results in:

    UndefVarError: fftfreq not defined

This PR:
- Imports `fftfreq` from AbstractFFTs in the test suite


This makes the dependency explicit and allows the test suite to run on
modern Julia versions without altering any functionality.