### PR TITLE
Fix CI: Explicitly import fftfreq in test suite to ensure pipeline stability

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Stingray
 using Test
-using FFTW, Distributions, Statistics, StatsBase, HDF5, FITSIO
+using FFTW
+using FFTW: fftfreq  # Explicitly importing fftfreq to resolve CI pipeline instabilities
+using Distributions, Statistics, StatsBase, HDF5, FITSIO
 using Logging ,LinearAlgebra
 using CFITSIO
 using Random


### PR DESCRIPTION
### Description
This PR addresses minor infrastructural instabilities within the Continuous Integration (CI) pipeline by explicitly importing `fftfreq` from `FFTW` in `test/runtests.jl`. 

Relying on implicit exports for core mathematical functions can cause resolution failures depending on the specific Julia environment and test container states. This surgical patch guarantees that the test suite possesses the correct function bindings before executing the Fourier modules, ensuring a more robust CI process.

### Checklist
- [x] Code strictly adheres to idiomatic Julia style guidelines.
- [x] Local environment tests pass cleanly.
- [x] Commit history is clean and descriptive.