### PR TITLE
fix: correct fftfreq sampling rate and histogram bin edges

### DIFF
--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -213,7 +213,8 @@ end
         end
         if !binned
             event_times = @view times[idx0:idx1-1]
-            cts = fit(Histogram,float.(event_times .- s);nbins=n_bin).weights
+            edges = range(0, stop=e - s, length=n_bin + 1)
+            cts = fit(Histogram, float.(event_times .- s), edges).weights
         else
             cts = float.(@view fluxes[idx0+1:idx1])
             if !isnothing(errors)
@@ -275,7 +276,7 @@ function avg_pds_from_iterable(flux_iterable, dt::Real; norm::String="frac",
         # In the first loop, define the frequency and the freq. interval > 0
         if isnothing(cross)
             fgt0 = positive_fft_bins(n_bin)
-            freq = fftfreq(n_bin, dt)[fgt0]
+            freq = fftfreq(n_bin, 1/dt)[fgt0]
         end
 
         # No need for the negative frequencies
@@ -362,7 +363,7 @@ function avg_cs_from_iterables_quick(flux_iterable1 ,flux_iterable2,
         # positive frequency bins (after the first loop, cross will not be
         # nothing anymore)
         if isnothing(unnorm_cross)
-            freq = fftfreq(n_bin, dt)
+            freq = fftfreq(n_bin, 1/dt)
             fgt0 = positive_fft_bins(n_bin)
         end
 
@@ -493,7 +494,7 @@ function avg_cs_from_iterables(
         # positive frequency bins (after the first loop, cross will not be
         # nothing anymore)
         if isnothing(cross)
-            freq = fftfreq(n_bin, dt)
+            freq = fftfreq(n_bin, 1/dt)
             fgt0 = positive_fft_bins(n_bin)
         end
 

--- a/test/test_fourier.jl
+++ b/test/test_fourier.jl
@@ -52,6 +52,40 @@ end
     @test filter(x -> x >0, freq) == freq[goodbins]
 end
 
+@testset "test_fftfreq_uses_sampling_rate" begin
+    dt = 0.5
+    segment_size = 50.0
+    n_bin = round(Int, segment_size / dt)
+    times = sort(rand(Uniform(0, 100), 10000))
+    gti = [[0 100];;]
+    result = avg_pds_from_events(times, gti, segment_size, dt, silent=true)
+    freqs = result[!, "freq"]
+    df = 1 / segment_size
+    @test freqs[1] ≈ df
+    @test (freqs[2] - freqs[1]) ≈ df
+    @test maximum(freqs) ≈ (n_bin ÷ 2 - 1) * df
+end
+
+@testset "test_histogram_bin_edges_align_with_segment" begin
+    segment_size = 10.0
+    n_bin = 20
+    dt = segment_size / n_bin
+    times = sort(rand(Uniform(0, 100), 5000))
+    gti = [[0 100];;]
+    flux_iter = collect(get_flux_iterable_from_segments(
+        times, gti, segment_size, n_bin=n_bin))
+    n_segments = round(Int, 100 / segment_size)
+    for (i, flux) in enumerate(flux_iter)
+        if !isnothing(flux) && !all(iszero, flux)
+            @test length(flux) == n_bin
+            seg_start = (i - 1) * segment_size
+            seg_end = i * segment_size
+            expected_count = count(t -> seg_start <= t < seg_end, times)
+            @test sum(flux) == expected_count
+        end
+    end
+end
+
 @testset "test_coherence" begin
 
     fid = h5open(joinpath(@__DIR__ ,"data","sample_variable_lc.h5"),"r")


### PR DESCRIPTION
Fix two bugs in the fourier module:

1. fftfreq(n_bin, dt) → fftfreq(n_bin, 1/dt): Julia's FFTW.fftfreq expects the sampling rate (1/dt), not the sample spacing (dt). The Python convention (numpy.fft.fftfreq) is the opposite, which caused incorrect frequency arrays when porting.

2. fit(Histogram, ...; nbins=n_bin) → fit(Histogram, ..., edges): Using nbins does not guarantee bin edges align with segment boundaries. Explicit edges via range(0, stop=e-s, length=n_bin+1) ensure deterministic, gap-free binning of unbinned event data.