### PR TITLE
ci: Add Codecov token and improve coverage configuration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          codecov_yml_path: .github/codecov.yml
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,9 +33,12 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+        with:
+          directories: src
+      - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR improves the Codecov integration in CI by:

- **Adding `CODECOV_TOKEN` secret** for reliable coverage uploads (required since `codecov-action` v4+)
- **Restricting coverage processing to `src/` only** — excludes test and docs files from coverage metrics for more accurate reporting
- **Bumping `codecov-action` from v5 to v7** (latest)

## Changes

```diff
- uses: julia-actions/julia-processcoverage@v1
+   with:
+     directories: src
- - uses: codecov/codecov-action@v5
+ - uses: codecov/codecov-action@v7
    with:
      files: lcov.info
+     token: ${{ secrets.CODECOV_TOKEN }}
```

## Note for Maintainers

> [!IMPORTANT]
> For Codecov uploads to work on the upstream repo, you will need to:
> 1. **Set up the repository** on [codecov.io](https://app.codecov.io) (sign in with GitHub and add `StingraySoftware/Stingray.jl`)
> 2. **Copy the Repository Upload Token** from Codecov → Configuration → General
> 3. **Add a GitHub repository secret** named `CODECOV_TOKEN` with the token value
>    - Go to repo Settings → Secrets and variables → Actions → New repository secret
>
> Without this secret, coverage uploads will silently fail on `codecov-action` v4+.
> For public repos, tokenless uploads may still work, but using a token is recommended for reliability.