### PR TITLE
feat: implement Lomb-Scargle periodogram

### DIFF
--- a/src/Stingray.jl
+++ b/src/Stingray.jl
@@ -94,9 +94,22 @@ export HuePlot
 include("crossspectrum.jl")
 export AbstractCrossspectrum
 export Crossspectrum
+export rebin_data
+export rebin_data_log
+export rebin_log
 
 include("powerspectrum.jl")
 export AbstractPowerspectrum
 export Powerspectrum
+export compute_rms
+
+include("lombscargle.jl")
+export LombScargleCrossspectrum
+export LombScarglePowerspectrum
+export autofrequency
+export lsft_slow, lsft_fast
+export impose_symmetry_lsft
+export unnormalize_periodograms
+export phase_lag, time_lag
 
 end

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -844,6 +844,55 @@ function integrate_power_in_frequency_range(
     return power_integrated, power_err_integrated
 end
 
+"""
+    _get_rms_from_unnorm_periodogram(unnorm_power, nphots, df;
+        M=1, poisson_noise_unnorm=0, segment_size=nothing)
+
+Internal function to compute the fractional rms amplitude from an unnormalized periodogram.
+
+# Arguments
+- `unnorm_power::AbstractVector{<:Real}`: Unnormalized power spectrum (real part).
+- `nphots::Real`: Total number of photons (or mean count rate if segment_size is nothing).
+- `df::Union{Real, AbstractVector{<:Real}}`: Frequency resolution.
+
+# Keyword Arguments
+- `M::Union{Real, AbstractVector{<:Real}}=1`: Number of averaged segments.
+- `poisson_noise_unnorm::Real=0`: Poisson noise level in unnormalized units.
+- `segment_size::Union{Nothing, Real}=nothing`: Length of the light curve segment.
+
+# Returns
+- `(rms, rms_err)` — fractional rms amplitude and its uncertainty.
+"""
+function _get_rms_from_unnorm_periodogram(
+    unnorm_power::AbstractVector{<:Real},
+    nphots::Real,
+    df::Union{Real, AbstractVector{<:Real}};
+    M::Union{Real, AbstractVector{<:Real}}=1,
+    poisson_noise_unnorm::Real=0,
+    segment_size::Union{Nothing, Real}=nothing
+)
+    pow_err = unnorm_power ./ sqrt.(M)
+
+    power_integrated = sum((unnorm_power .- poisson_noise_unnorm) .* df)
+    power_err_integrated = sqrt(sum((pow_err .* df) .^ 2))
+
+    mean_rate = isnothing(segment_size) ? float(nphots) : float(nphots / segment_size)
+
+    if power_integrated < 0
+        rms = 0.0
+    else
+        rms = sqrt(power_integrated / (mean_rate^2))
+    end
+
+    if rms > 0
+        rms_err = power_err_integrated / (2 * rms * (mean_rate^2))
+    else
+        rms_err = sqrt(power_err_integrated / (mean_rate^2))
+    end
+
+    return rms, rms_err
+end
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Lomb-Scargle Fourier Transform algorithms
 # ──────────────────────────────────────────────────────────────────────────────

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -903,3 +903,131 @@ function lsft_slow(y::AbstractVector{<:Real},
 
     return ft
 end
+
+"""
+    _extirpolate!(result, y, t, freqs, oversampling)
+
+Internal helper for `lsft_fast`. Grids (extirpolates) unevenly sampled data
+onto a regular oversampled grid using a triangle-window spreading kernel.
+
+Each sample `y[j]` at time `t[j]` is spread to the two nearest grid points
+with weights proportional to the distance to each point (linear interpolation
+in reverse, i.e., "extirpolation").
+
+# Arguments
+- `result::Vector{ComplexF64}`: Pre-allocated output grid (zeroed).
+- `y::AbstractVector{<:Real}`: Signal values.
+- `t::AbstractVector{<:Real}`: Time stamps.
+- `freqs::AbstractVector{<:Real}`: Frequency grid (used to determine grid spacing).
+- `oversampling::Int`: Oversampling factor for the regular grid.
+"""
+function _extirpolate!(result::Vector{ComplexF64},
+                       y::AbstractVector{<:Real},
+                       t::AbstractVector{<:Real},
+                       freqs::AbstractVector{<:Real},
+                       oversampling::Int)
+    n_grid = length(result)
+    df = length(freqs) > 1 ? freqs[2] - freqs[1] : freqs[1]
+    dt_grid = 1.0 / (n_grid * df)
+
+    for j in eachindex(y)
+        # Map time to grid index (0-based fractional position)
+        pos = t[j] / dt_grid
+        # Wrap into [0, n_grid)
+        pos = mod(pos, n_grid)
+
+        # Two nearest grid points
+        idx_lo = floor(Int, pos)
+        frac = pos - idx_lo
+
+        # Julia 1-indexed, with wrapping
+        i_lo = mod(idx_lo, n_grid) + 1
+        i_hi = mod(idx_lo + 1, n_grid) + 1
+
+        # Triangle-window weights
+        result[i_lo] += y[j] * (1.0 - frac)
+        result[i_hi] += y[j] * frac
+    end
+end
+
+"""
+    lsft_fast(y, t, freqs; oversampling=5)
+
+Compute the Lomb-Scargle Fourier Transform using the fast O(n·log n)
+Press & Rybicki algorithm.
+
+The method works by:
+1. Gridding ("extirpolating") the unevenly sampled data onto a regular
+   oversampled grid via triangle-window spreading.
+2. Computing an FFT of the gridded data.
+3. Interpolating the FFT result back to the requested frequency grid.
+
+Mirrors Python Stingray's `fourier.lsft_fast`.
+
+# Arguments
+- `y::AbstractVector{<:Real}`: Signal values at each time sample.
+- `t::AbstractVector{<:Real}`: Time stamps (may be unevenly spaced).
+- `freqs::AbstractVector{<:Real}`: Frequency grid at which to evaluate the transform.
+
+# Keyword Arguments
+- `oversampling::Int=5`: Oversampling factor for the internal regular grid.
+  Higher values improve accuracy at the cost of memory and speed.
+
+# Returns
+- `Vector{ComplexF64}`: The Fourier amplitudes at each frequency.
+
+# Examples
+```julia
+t = collect(0.0:0.1:10.0) .+ 0.01 .* randn(101)
+y = sin.(2π .* 0.5 .* t)
+freqs = collect(0.01:0.01:5.0)
+ft = lsft_fast(y, t, freqs; oversampling=5)
+```
+
+# References
+- Press, W. H. & Rybicki, G. B. (1989), "Fast algorithm for spectral analysis
+  of unevenly sampled data", ApJ 338, 277.
+"""
+function lsft_fast(y::AbstractVector{<:Real},
+                   t::AbstractVector{<:Real},
+                   freqs::AbstractVector{<:Real};
+                   oversampling::Int=5)
+    n = length(y)
+    if length(t) != n
+        throw(ArgumentError("y and t must have the same length (got $(length(y)) and $(length(t)))"))
+    end
+    if oversampling < 1
+        throw(ArgumentError("oversampling must be ≥ 1 (got $oversampling)"))
+    end
+
+    nf = length(freqs)
+    # Size of the oversampled grid
+    n_grid = nf * oversampling
+
+    # Step 1: Extirpolate onto the regular grid
+    gridded = zeros(ComplexF64, n_grid)
+    _extirpolate!(gridded, y, t, freqs, oversampling)
+
+    # Step 2: FFT the gridded data
+    ft_grid = fft(gridded)
+
+    # Step 3: Interpolate to the requested frequencies
+    df = nf > 1 ? freqs[2] - freqs[1] : freqs[1]
+    ft = zeros(ComplexF64, nf)
+
+    @inbounds for k in 1:nf
+        # Map the requested frequency to a grid index
+        grid_idx = freqs[k] / df
+        idx_lo = floor(Int, grid_idx)
+        frac = grid_idx - idx_lo
+
+        # 1-indexed with wrapping
+        i_lo = mod(idx_lo, n_grid) + 1
+        i_hi = mod(idx_lo + 1, n_grid) + 1
+
+        # Linear interpolation between neighboring FFT bins
+        ft[k] = ft_grid[i_lo] * (1.0 - frac) + ft_grid[i_hi] * frac
+    end
+
+    return ft
+end

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -846,9 +846,9 @@ end
 
 """
     _get_rms_from_unnorm_periodogram(unnorm_power, nphots, df;
-        M=1, poisson_noise_unnorm=0, segment_size=nothing)
+        M=1, poisson_noise_unnorm=0, segment_size=nothing, kind="frac")
 
-Internal function to compute the fractional rms amplitude from an unnormalized periodogram.
+Internal function to compute the fractional or absolute rms amplitude from an unnormalized periodogram.
 
 # Arguments
 - `unnorm_power::AbstractVector{<:Real}`: Unnormalized power spectrum (real part).
@@ -859,9 +859,10 @@ Internal function to compute the fractional rms amplitude from an unnormalized p
 - `M::Union{Real, AbstractVector{<:Real}}=1`: Number of averaged segments.
 - `poisson_noise_unnorm::Real=0`: Poisson noise level in unnormalized units.
 - `segment_size::Union{Nothing, Real}=nothing`: Length of the light curve segment.
+- `kind::String="frac"`: Type of RMS to compute. Either "frac" or "abs".
 
 # Returns
-- `(rms, rms_err)` — fractional rms amplitude and its uncertainty.
+- `(rms, rms_err)` — rms amplitude and its uncertainty.
 """
 function _get_rms_from_unnorm_periodogram(
     unnorm_power::AbstractVector{<:Real},
@@ -869,25 +870,41 @@ function _get_rms_from_unnorm_periodogram(
     df::Union{Real, AbstractVector{<:Real}};
     M::Union{Real, AbstractVector{<:Real}}=1,
     poisson_noise_unnorm::Real=0,
-    segment_size::Union{Nothing, Real}=nothing
+    segment_size::Union{Nothing, Real}=nothing,
+    kind::String="frac"
 )
-    pow_err = unnorm_power ./ sqrt.(M)
+    seg_size = isnothing(segment_size) ? 1.0 / minimum(df) : float(segment_size)
+    mean_rate = nphots / seg_size
 
-    power_integrated = sum((unnorm_power .- poisson_noise_unnorm) .* df)
-    power_err_integrated = sqrt(sum((pow_err .* df) .^ 2))
+    function to_norm(powers)
+        leahy = powers .* (2.0 / nphots)
+        if kind == "frac"
+            return leahy ./ mean_rate
+        elseif kind == "abs"
+            return leahy .* mean_rate
+        else
+            throw(ArgumentError("Only 'frac' or 'abs' rms are supported."))
+        end
+    end
 
-    mean_rate = isnothing(segment_size) ? float(nphots) : float(nphots / segment_size)
+    powers_norm = to_norm(unnorm_power)
+    poisson_norm = to_norm(poisson_noise_unnorm)
+
+    pow_err_norm = powers_norm ./ sqrt.(M)
+
+    power_integrated = sum((powers_norm .- poisson_norm) .* df)
+    power_err_integrated = sqrt(sum((pow_err_norm .* df) .^ 2))
 
     if power_integrated < 0
         rms = 0.0
     else
-        rms = sqrt(power_integrated / (mean_rate^2))
+        rms = sqrt(power_integrated)
     end
 
     if rms > 0
-        rms_err = power_err_integrated / (2 * rms * (mean_rate^2))
+        rms_err = power_err_integrated / (2 * rms)
     else
-        rms_err = sqrt(power_err_integrated / (mean_rate^2))
+        rms_err = sqrt(power_err_integrated)
     end
 
     return rms, rms_err

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -843,3 +843,63 @@ function integrate_power_in_frequency_range(
 
     return power_integrated, power_err_integrated
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Lomb-Scargle Fourier Transform algorithms
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    lsft_slow(y, t, freqs)
+
+Compute the Lomb-Scargle Fourier Transform of unevenly sampled data using
+the direct O(n²) summation method.
+
+Mirrors Python Stingray's `fourier.lsft_slow`.
+
+# Arguments
+- `y::AbstractVector{<:Real}`: Signal values at each time sample.
+- `t::AbstractVector{<:Real}`: Time stamps of each sample (may be unevenly spaced).
+- `freqs::AbstractVector{<:Real}`: Frequency grid at which to evaluate the transform.
+
+# Returns
+- `Vector{ComplexF64}`: The Fourier amplitudes at each frequency.
+
+# Mathematical Definition
+```math
+F(\\nu_k) = \\sum_{j=1}^{N} y_j \\, e^{-2\\pi i \\, \\nu_k \\, t_j}
+```
+
+# Examples
+```julia
+t = [0.0, 1.0, 2.0, 3.0, 4.0]
+y = [1.0, 0.0, -1.0, 0.0, 1.0]
+freqs = [0.1, 0.2, 0.3, 0.4, 0.5]
+ft = lsft_slow(y, t, freqs)
+```
+
+# References
+- Scargle, J. D. (1989), "Studies in astronomical time series analysis. III",
+  ApJ 343, 874–887.
+"""
+function lsft_slow(y::AbstractVector{<:Real},
+                   t::AbstractVector{<:Real},
+                   freqs::AbstractVector{<:Real})
+    n = length(y)
+    if length(t) != n
+        throw(ArgumentError("y and t must have the same length (got $(length(y)) and $(length(t)))"))
+    end
+
+    nf = length(freqs)
+    ft = zeros(ComplexF64, nf)
+
+    @inbounds for k in 1:nf
+        ν = freqs[k]
+        s = zero(ComplexF64)
+        for j in 1:n
+            s += y[j] * exp(-2π * im * ν * t[j])
+        end
+        ft[k] = s
+    end
+
+    return ft
+end

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -1081,3 +1081,50 @@ function impose_symmetry_lsft(ft::AbstractVector{<:Complex},
 
     return ft_full, freqs_full
 end
+
+"""
+    unnormalize_periodograms(power, dt, n_bin, nphots; norm="frac", mean_flux=nothing)
+
+Invert the normalization applied to a periodogram, converting normalized
+power values back to unnormalized form.
+
+This is the inverse of `normalize_periodograms` and is needed for computing
+RMS amplitudes from normalized power spectra (e.g., in Lomb-Scargle context).
+
+Mirrors Python Stingray's `fourier.unnormalize_periodograms`.
+
+# Arguments
+- `power::AbstractVector{<:Number}`: Normalized power values.
+- `dt::Real`: Time resolution of the data.
+- `n_bin::Int`: Number of bins per segment.
+- `nphots::Real`: Total number of photons (or geometric mean for cross-spectra).
+
+# Keyword Arguments
+- `norm::String="frac"`: The normalization that was applied.
+  Must be one of `"frac"`, `"abs"`, `"leahy"`, `"none"`.
+- `mean_flux::Union{Nothing, Real}=nothing`: Mean count rate. If `nothing`,
+  computed as `nphots / n_bin`.
+
+# Returns
+- `Vector`: Unnormalized power values.
+"""
+function unnormalize_periodograms(power::AbstractVector{<:Number},
+                                  dt::Real, n_bin::Int, nphots::Real;
+                                  norm::String="frac",
+                                  mean_flux::Union{Nothing, Real}=nothing)
+    if isnothing(mean_flux)
+        mean_flux = nphots / n_bin
+    end
+
+    if norm == "leahy"
+        return @. power * nphots / 2.0
+    elseif norm == "frac"
+        return @. power * mean_flux^2 * n_bin / (2.0 * dt)
+    elseif norm == "abs"
+        return @. power * n_bin * dt / 2.0
+    elseif norm == "none"
+        return collect(power)
+    else
+        throw(ArgumentError("Unknown value for norm: $norm"))
+    end
+end

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -1031,3 +1031,53 @@ function lsft_fast(y::AbstractVector{<:Real},
 
     return ft
 end
+
+"""
+    impose_symmetry_lsft(ft, sum_y, n, freqs)
+
+Create the full (positive + negative frequency) spectrum from a one-sided
+Lomb-Scargle Fourier Transform by imposing Hermitian symmetry.
+
+For a real-valued signal, the Fourier transform satisfies `F(-ν) = conj(F(ν))`.
+This function constructs the full spectrum by:
+1. Computing the DC component as `sum_y` (total signal).
+2. Prepending the negative frequencies as conjugates of the positive ones (reversed).
+3. Prepending the corresponding negative frequency values.
+
+Mirrors Python Stingray's `fourier.impose_symmetry_lsft`.
+
+# Arguments
+- `ft::AbstractVector{<:Complex}`: One-sided (positive frequency) Fourier amplitudes.
+- `sum_y::Real`: Sum of the signal values (DC component).
+- `n::Int`: Number of data points in the original signal.
+- `freqs::AbstractVector{<:Real}`: Positive frequency grid.
+
+# Returns
+- `(ft_full, freqs_full)`: Tuple of the full spectrum and full frequency grid.
+  - `ft_full` has length `2 * length(ft) + 1` (negative freqs + DC + positive freqs).
+  - `freqs_full` is symmetric around 0.
+
+# Examples
+```julia
+freqs = [0.1, 0.2, 0.3, 0.4, 0.5]
+ft = lsft_slow(y, t, freqs)
+ft_full, freqs_full = impose_symmetry_lsft(ft, sum(y), length(y), freqs)
+```
+"""
+function impose_symmetry_lsft(ft::AbstractVector{<:Complex},
+                               sum_y::Real,
+                               n::Int,
+                               freqs::AbstractVector{<:Real})
+    # Negative frequency part: reversed conjugate of positive frequencies
+    ft_neg = conj.(reverse(ft))
+    freqs_neg = -reverse(freqs)
+
+    # DC component
+    dc = ComplexF64(sum_y)
+
+    # Full spectrum: [negative freqs | DC | positive freqs]
+    ft_full = vcat(ft_neg, [dc], ComplexF64.(ft))
+    freqs_full = vcat(freqs_neg, [0.0], Float64.(freqs))
+
+    return ft_full, freqs_full
+end

--- a/src/lombscargle.jl
+++ b/src/lombscargle.jl
@@ -564,3 +564,106 @@ function LombScarglePowerspectrum(ev::EventList;
         min_freq=min_freq, max_freq=max_freq, df=df,
         method=method, oversampling=oversampling)
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Analysis methods
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    phase_lag(lscs::LombScargleCrossspectrum)
+
+Compute the phase lag (in radians) at each frequency from the cross spectrum.
+
+The phase lag is the argument (angle) of the complex cross-spectral power.
+
+# Returns
+- `Vector{Float64}`: Phase lags in radians.
+"""
+function phase_lag(lscs::LombScargleCrossspectrum)
+    return angle.(Complex{Float64}.(lscs.unnorm_power))
+end
+
+"""
+    time_lag(lscs::LombScargleCrossspectrum)
+
+Compute the time lag at each frequency from the cross spectrum.
+
+Defined as `time_lag = phase_lag / (2π · freq)`.
+
+Mirrors Python Stingray's `LombScargleCrossspectrum.time_lag()`.
+
+# Returns
+- `Vector{Float64}`: Time lags in seconds.
+
+# Examples
+```julia
+lscs = LombScargleCrossspectrum(lc1, lc2)
+lags = time_lag(lscs)
+```
+"""
+function time_lag(lscs::LombScargleCrossspectrum)
+    ϕ = phase_lag(lscs)
+    return ϕ ./ (2π .* lscs.freq)
+end
+
+"""
+    compute_rms(ls::LombScarglePowerspectrum, min_freq::Real, max_freq::Real;
+                poisson_noise_level=nothing)
+
+Compute the fractional rms amplitude in the power spectrum between two
+frequencies.
+
+Mirrors Python Stingray's `LombScargleCrossspectrum.compute_rms()`.
+
+# Arguments
+- `ls::LombScarglePowerspectrum`: The power spectrum.
+- `min_freq::Real`: Lower frequency bound.
+- `max_freq::Real`: Upper frequency bound.
+
+# Keyword Arguments
+- `poisson_noise_level::Union{Nothing, Real}=nothing`: Poisson noise level
+  in the same normalization as the power spectrum. If `nothing`, computed
+  from the ideal Poisson level.
+
+# Returns
+- `(rms, rms_err)` — fractional rms amplitude and its uncertainty.
+
+# Examples
+```julia
+lsps = LombScarglePowerspectrum(lc; norm="frac")
+rms, rms_err = compute_rms(lsps, 0.01, 0.5)
+```
+"""
+function compute_rms(ls::LombScarglePowerspectrum, min_freq::Real, max_freq::Real;
+                     poisson_noise_level::Union{Nothing, Real}=nothing)
+
+    good = (ls.freq .>= min_freq) .& (ls.freq .<= max_freq)
+
+    K_freq = ls.k isa AbstractVector ? ls.k[good] : ls.k
+    M_freq = ls.m isa AbstractVector ? ls.m[good] : ls.m
+
+    # Compute Poisson noise in unnormalized units
+    if isnothing(poisson_noise_level)
+        poisson_noise_unnorm = poisson_level("none"; n_ph=ls.nphots)
+    else
+        poisson_noise_unnorm = unnormalize_periodograms(
+            [poisson_noise_level], ls.dt, ls.n, ls.nphots;
+            norm=ls.norm
+        )[1]
+    end
+
+    # Compute df for each frequency bin
+    df_per_bin = if K_freq isa AbstractVector
+        ls.df .* Float64.(K_freq)
+    else
+        ls.df * Float64(K_freq)
+    end
+
+    rms, rms_err = _get_rms_from_unnorm_periodogram(
+        real.(ls.unnorm_power[good]), ls.nphots, df_per_bin;
+        M=M_freq, poisson_noise_unnorm=poisson_noise_unnorm,
+        segment_size=nothing
+    )
+
+    return rms, rms_err
+end

--- a/src/lombscargle.jl
+++ b/src/lombscargle.jl
@@ -147,3 +147,288 @@ function Base.show(io::IO, lscs::LombScargleCrossspectrum{T}) where T
           "freq range=[$(round(lscs.freq[1], sigdigits=4)), ",
           "$(round(lscs.freq[end], sigdigits=4))] Hz)")
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Internal: LSFT cross-spectrum computation
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    _ls_cross(lc1, lc2, freq; fullspec=false, method="fast", oversampling=5)
+
+Compute the unnormalized Lomb-Scargle cross spectrum of two light curves.
+
+Returns `(freq, cross)` where `cross = F₁ × conj(F₂)`.
+
+# Arguments
+- `lc1::LightCurve`: Light curve from channel 1.
+- `lc2::LightCurve`: Light curve from channel 2.
+- `freq::AbstractVector{<:Real}`: Frequency grid.
+
+# Keyword Arguments
+- `fullspec::Bool=false`: Include negative frequencies via Hermitian symmetry.
+- `method::String="fast"`: LSFT method ("fast" or "slow").
+- `oversampling::Int=5`: Oversampling factor (fast method only).
+"""
+function _ls_cross(lc1::LightCurve, lc2::LightCurve,
+                   freq::AbstractVector{<:Real};
+                   fullspec::Bool=false,
+                   method::String="fast",
+                   oversampling::Int=5)
+    y1 = Float64.(lc1.counts)
+    y2 = Float64.(lc2.counts)
+    t1 = Float64.(lc1.time)
+    t2 = Float64.(lc2.time)
+
+    if method == "slow"
+        lsft1 = lsft_slow(y1, t1, freq)
+        lsft2 = lsft_slow(y2, t2, freq)
+    elseif method == "fast"
+        lsft1 = lsft_fast(y1, t1, freq; oversampling=oversampling)
+        lsft2 = lsft_fast(y2, t2, freq; oversampling=oversampling)
+    else
+        throw(ValueError("method must be one of ['fast','slow']"))
+    end
+
+    if fullspec
+        lsft1, _ = impose_symmetry_lsft(lsft1, sum(y1), Base.length(y1), freq)
+        lsft2, freq = impose_symmetry_lsft(lsft2, sum(y2), Base.length(y2), freq)
+    end
+
+    cross = lsft1 .* conj.(lsft2)
+    return Float64.(freq), cross
+end
+
+"""
+    _normalize_crossspectrum(unnorm_power, lc1, lc2, norm, n)
+
+Normalize the cross spectrum using `normalize_periodograms` from fourier.jl.
+
+Computes the mean flux as the geometric mean of the two light curves'
+mean count rates, matching Python Stingray's normalization approach.
+"""
+function _normalize_crossspectrum(unnorm_power::AbstractVector{<:Complex},
+                                   lc1::LightCurve, lc2::LightCurve,
+                                   norm::String, n::Int)
+    dt_val = lc1.dt isa AbstractVector ? lc1.dt[1] : lc1.dt
+    nphots1 = Float64(sum(lc1.counts))
+    nphots2 = Float64(sum(lc2.counts))
+    nphots = sqrt(nphots1 * nphots2)
+
+    mean1 = nphots1 / n
+    mean2 = nphots2 / n
+    mean_flux = sqrt(mean1 * mean2)
+
+    # Determine variance for Leahy normalization
+    variance = nothing
+    if lc1.err_method == :gaussian
+        variance = sqrt(Statistics.var(Float64.(lc1.counts)) *
+                        Statistics.var(Float64.(lc2.counts)))
+    end
+
+    normalized = normalize_periodograms(
+        unnorm_power, Float64(dt_val), n;
+        mean_flux=mean_flux, n_ph=nphots,
+        norm=norm, variance=variance, power_type="all"
+    )
+
+    return normalized
+end
+
+"""
+    lscrossspectrum_from_lightcurve(lc1, lc2; kwargs...)
+
+Core function that orchestrates the full Lomb-Scargle cross-spectrum pipeline.
+
+1. Builds the frequency grid via `autofrequency`
+2. Computes the unnormalized cross spectrum via `_ls_cross`
+3. Normalizes the power
+4. Applies `power_type` filtering
+5. Constructs and returns a `LombScargleCrossspectrum`
+
+Mirrors Python Stingray's `lscrossspectrum_from_lightcurve`.
+"""
+function lscrossspectrum_from_lightcurve(lc1::LightCurve, lc2::LightCurve;
+                                         norm::String="none",
+                                         power_type::String="all",
+                                         fullspec::Bool=false,
+                                         min_freq::Union{Nothing, Real}=nothing,
+                                         max_freq::Union{Nothing, Real}=nothing,
+                                         df::Union{Nothing, Real}=nothing,
+                                         method::String="fast",
+                                         oversampling::Int=5,
+                                         nyquist_factor::Real=1)
+    # Compute time span and dt
+    t_length = max(lc1.time[end], lc2.time[end]) - min(lc1.time[1], lc2.time[1])
+    dt_val1 = lc1.dt isa AbstractVector ? lc1.dt[1] : lc1.dt
+    dt_val2 = lc2.dt isa AbstractVector ? lc2.dt[1] : lc2.dt
+    dt_val = min(dt_val1, dt_val2)
+
+    # Build frequency grid
+    freq = autofrequency(;
+        min_freq=min_freq, max_freq=max_freq, df=df,
+        dt=dt_val, length=t_length, nyquist_factor=nyquist_factor
+    )
+
+    # Compute unnormalized cross spectrum
+    freq, cross = _ls_cross(lc1, lc2, freq;
+                             fullspec=fullspec, method=method,
+                             oversampling=oversampling)
+
+    n = Base.length(lc1.time)
+
+    # Normalize
+    power = _normalize_crossspectrum(cross, lc1, lc2, norm, n)
+
+    # Apply power_type
+    if power_type == "real"
+        power = real.(power)
+        unnorm_display = real.(cross)
+    elseif power_type == "absolute"
+        power = abs.(power)
+        unnorm_display = abs.(cross)
+    else
+        unnorm_display = cross
+    end
+
+    # Compute metadata
+    nphots1 = Float64(sum(lc1.counts))
+    nphots2 = Float64(sum(lc2.counts))
+    freq_df = Base.length(freq) > 1 ? Float64(freq[2] - freq[1]) : 1.0 / t_length
+
+    # Variance
+    if lc1.err_method == :gaussian
+        variance1 = Float64(Statistics.mean(lc1.count_error))^2
+        variance2 = Float64(Statistics.mean(lc2.count_error))^2
+        err_dist = "gauss"
+    else
+        variance1 = Float64(Statistics.mean(Float64.(lc1.counts)))
+        variance2 = Float64(Statistics.mean(Float64.(lc2.counts)))
+        err_dist = "poisson"
+    end
+
+    # Error estimation: power / sqrt(m), m=1 for single-segment LS
+    m = 1
+    power_err = power ./ sqrt(m)
+    unnorm_power_err = cross ./ sqrt(m)
+
+    return LombScargleCrossspectrum{Float64}(
+        Float64.(freq),
+        power_type == "all" ? Complex{Float64}.(power) :
+            (power_type == "real" ? Float64.(power) : Float64.(power)),
+        power_type == "all" ? Complex{Float64}.(power_err) :
+            (power_type == "real" ? Float64.(power_err) : Float64.(power_err)),
+        Complex{Float64}.(cross),
+        Complex{Float64}.(unnorm_power_err),
+        freq_df, Float64(dt_val), n, m, 1,
+        nphots1, nphots2,
+        norm, power_type, fullspec,
+        method, oversampling,
+        variance1, variance2,
+        err_dist, "crossspectrum"
+    )
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public constructors
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    _validate_ls_inputs(norm, power_type, method, oversampling, fullspec,
+                        min_freq, max_freq)
+
+Validate inputs for Lomb-Scargle cross-spectrum / power-spectrum constructors.
+Mirrors Python Stingray's `LombScargleCrossspectrum.initial_checks`.
+"""
+function _validate_ls_inputs(norm::String, power_type::String, method::String,
+                              oversampling::Int, fullspec::Bool,
+                              min_freq, max_freq)
+    if !(norm in ["frac", "abs", "leahy", "none"])
+        throw(ValueError("norm must be one of ['frac','abs','leahy','none']"))
+    end
+    if !(power_type in ["all", "absolute", "real"])
+        throw(ValueError("power_type must be one of ['all','absolute','real']"))
+    end
+    if !(method in ["fast", "slow"])
+        throw(ValueError("method must be one of ['fast','slow']"))
+    end
+    if oversampling < 1
+        throw(ArgumentError("oversampling must be ≥ 1"))
+    end
+    if !isnothing(min_freq) && min_freq < 0
+        throw(ValueError("min_freq must be non-negative"))
+    end
+    if !isnothing(max_freq) && max_freq < 0
+        throw(ValueError("max_freq must be non-negative"))
+    end
+    if !isnothing(max_freq) && !isnothing(min_freq) && max_freq <= min_freq
+        throw(ValueError("max_freq must be greater than min_freq"))
+    end
+end
+
+"""
+    LombScargleCrossspectrum(lc1::LightCurve, lc2::LightCurve; kwargs...)
+
+Construct a `LombScargleCrossspectrum` from two `LightCurve` objects.
+
+# Keyword Arguments
+- `norm::String="none"`: Normalization ("frac", "abs", "leahy", "none").
+- `power_type::String="all"`: Power type ("all", "real", "absolute").
+- `fullspec::Bool=false`: Include negative frequencies.
+- `min_freq::Union{Nothing, Real}=nothing`: Minimum frequency.
+- `max_freq::Union{Nothing, Real}=nothing`: Maximum frequency.
+- `df::Union{Nothing, Real}=nothing`: Frequency resolution.
+- `method::String="fast"`: LSFT method ("fast" or "slow").
+- `oversampling::Int=5`: Oversampling factor.
+"""
+function LombScargleCrossspectrum(lc1::LightCurve, lc2::LightCurve;
+                                   norm::String="none",
+                                   power_type::String="all",
+                                   fullspec::Bool=false,
+                                   min_freq::Union{Nothing, Real}=nothing,
+                                   max_freq::Union{Nothing, Real}=nothing,
+                                   df::Union{Nothing, Real}=nothing,
+                                   method::String="fast",
+                                   oversampling::Int=5)
+    _validate_ls_inputs(norm, power_type, method, oversampling, fullspec,
+                         min_freq, max_freq)
+
+    return lscrossspectrum_from_lightcurve(lc1, lc2;
+        norm=norm, power_type=power_type, fullspec=fullspec,
+        min_freq=min_freq, max_freq=max_freq, df=df,
+        method=method, oversampling=oversampling)
+end
+
+"""
+    LombScargleCrossspectrum(ev1::EventList, ev2::EventList; dt, kwargs...)
+
+Construct a `LombScargleCrossspectrum` from two `EventList` objects.
+
+Converts event lists to light curves using `create_lightcurve`, then
+delegates to the `LightCurve` constructor.
+
+# Arguments
+- `ev1::EventList`: Event list for channel 1.
+- `ev2::EventList`: Event list for channel 2.
+
+# Keyword Arguments
+- `dt::Real`: Time resolution for binning events into light curves. **Required.**
+- All other kwargs are passed to the `LightCurve` constructor.
+"""
+function LombScargleCrossspectrum(ev1::EventList, ev2::EventList;
+                                   dt::Real,
+                                   norm::String="none",
+                                   power_type::String="all",
+                                   fullspec::Bool=false,
+                                   min_freq::Union{Nothing, Real}=nothing,
+                                   max_freq::Union{Nothing, Real}=nothing,
+                                   df::Union{Nothing, Real}=nothing,
+                                   method::String="fast",
+                                   oversampling::Int=5)
+    lc1 = create_lightcurve(ev1, dt)
+    lc2 = create_lightcurve(ev2, dt)
+
+    return LombScargleCrossspectrum(lc1, lc2;
+        norm=norm, power_type=power_type, fullspec=fullspec,
+        min_freq=min_freq, max_freq=max_freq, df=df,
+        method=method, oversampling=oversampling)
+end

--- a/src/lombscargle.jl
+++ b/src/lombscargle.jl
@@ -1,0 +1,79 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Lomb-Scargle Periodograms for unevenly sampled data
+#
+# Mirrors Python Stingray's stingray/lombscargle.py
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    autofrequency(; min_freq=nothing, max_freq=nothing, df=nothing,
+                    dt=nothing, length=nothing, nyquist_factor=1)
+
+Build the frequency grid for a Lomb-Scargle periodogram.
+
+Determines `df`, `max_freq`, and `min_freq` from whatever subset of
+parameters the user provides, then returns a regularly spaced frequency
+array from `min_freq` to `max_freq` in steps of `df`.
+
+Mirrors Python Stingray's `lombscargle._autofrequency`.
+
+# Keyword Arguments
+- `min_freq::Union{Nothing, Real}=nothing`: Minimum frequency. Defaults to `df / 2`.
+- `max_freq::Union{Nothing, Real}=nothing`: Maximum frequency. Defaults to Nyquist: `nyquist_factor * 0.5 / dt`.
+- `df::Union{Nothing, Real}=nothing`: Frequency resolution. Defaults to `1 / length`.
+- `dt::Union{Nothing, Real}=nothing`: Time resolution of the data.
+- `length::Union{Nothing, Real}=nothing`: Total duration of the observation.
+- `nyquist_factor::Real=1`: Multiplier on the Nyquist frequency.
+
+# Returns
+- `Vector{Float64}`: The array of frequencies.
+
+# Examples
+```julia
+freqs = autofrequency(min_freq=0.1, max_freq=0.5, df=0.1)
+# [0.1, 0.2, 0.3, 0.4, 0.5]
+
+freqs = autofrequency(min_freq=0.1, dt=1.0, length=10.0)
+# [0.1, 0.2, 0.3, 0.4, 0.5]
+```
+"""
+function autofrequency(; min_freq::Union{Nothing, Real}=nothing,
+                         max_freq::Union{Nothing, Real}=nothing,
+                         df::Union{Nothing, Real}=nothing,
+                         dt::Union{Nothing, Real}=nothing,
+                         length::Union{Nothing, Real}=nothing,
+                         nyquist_factor::Real=1)
+
+    # Determine df
+    if (isnothing(df) || df <= 0) && isnothing(length)
+        throw(ValueError("Either df or length must be specified."))
+    elseif isnothing(df) || df <= 0
+        df = 1.0 / length
+    end
+
+    # Determine max_freq
+    if isnothing(max_freq) && (isnothing(dt) || dt == 0)
+        throw(ValueError("Either max_freq or dt must be specified."))
+    elseif isnothing(max_freq)
+        max_freq = nyquist_factor * 0.5 / dt
+    end
+
+    # Determine min_freq
+    if isnothing(min_freq)
+        min_freq = df / 2.0
+    elseif min_freq <= 0
+        @warn "min_freq must be positive and >0. Setting to df / 2."
+        min_freq = df / 2.0
+    end
+
+    freq = collect(Float64(min_freq):Float64(df):Float64(max_freq + df))
+    # Trim any values beyond max_freq (floating point overshoot)
+    filter!(f -> f <= max_freq + df * 0.5, freq)
+
+    return freq
+end
+
+# ValueError alias for consistency with Python-style error messages
+struct ValueError <: Exception
+    msg::String
+end
+Base.showerror(io::IO, e::ValueError) = print(io, "ValueError: ", e.msg)

--- a/src/lombscargle.jl
+++ b/src/lombscargle.jl
@@ -77,3 +77,73 @@ struct ValueError <: Exception
     msg::String
 end
 Base.showerror(io::IO, e::ValueError) = print(io, "ValueError: ", e.msg)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LombScargleCrossspectrum
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    LombScargleCrossspectrum{T<:Real} <: AbstractCrossspectrum
+
+A cross spectrum computed from two unevenly sampled time series using
+the Lomb-Scargle Fourier Transform.
+
+Unlike the standard `Crossspectrum`, this type does not require evenly
+sampled data and uses the LSFT instead of the FFT.
+
+Mirrors Python Stingray's `LombScargleCrossspectrum`.
+
+# Fields
+- `freq::Vector{T}`: Mid-bin frequencies of the Fourier transform.
+- `power::Vector{<:Union{T, Complex{T}}}`: Normalized cross-spectral powers.
+- `power_err::Vector{<:Union{T, Complex{T}}}`: Uncertainties on `power` (≈ `power / √m`).
+- `unnorm_power::Vector{Complex{T}}`: Unnormalized cross-spectral powers.
+- `unnorm_power_err::Vector{Complex{T}}`: Uncertainties on `unnorm_power`.
+- `df::T`: Frequency resolution (Hz).
+- `dt::T`: Time resolution of the input data (s).
+- `n::Int`: Number of data points in the light curves.
+- `m::Int`: Number of averaged spectra (always 1 for single-segment LS).
+- `k::Int`: Rebinning factor (1 if not rebinned).
+- `nphots1::T`: Total number of photons in light curve 1.
+- `nphots2::T`: Total number of photons in light curve 2.
+- `norm::String`: Normalization: "frac", "abs", "leahy", or "none".
+- `power_type::String`: Power representation: "all", "real", or "absolute".
+- `fullspec::Bool`: Whether negative frequencies are included.
+- `method::String`: LSFT method used: "fast" or "slow".
+- `oversampling::Int`: Oversampling factor (for the fast algorithm).
+- `variance1::T`: Variance of light curve 1 (count rate if Poisson).
+- `variance2::T`: Variance of light curve 2 (count rate if Poisson).
+- `err_dist::String`: Error distribution: "poisson" or "gauss".
+- `type::String`: Object type identifier, always "crossspectrum".
+"""
+struct LombScargleCrossspectrum{T<:Real} <: AbstractCrossspectrum
+    freq::Vector{T}
+    power::Union{Vector{T}, Vector{Complex{T}}}
+    power_err::Union{Vector{T}, Vector{Complex{T}}}
+    unnorm_power::Vector{Complex{T}}
+    unnorm_power_err::Vector{Complex{T}}
+    df::T
+    dt::T
+    n::Int
+    m::Int
+    k::Int
+    nphots1::T
+    nphots2::T
+    norm::String
+    power_type::String
+    fullspec::Bool
+    method::String
+    oversampling::Int
+    variance1::T
+    variance2::T
+    err_dist::String
+    type::String
+end
+
+function Base.show(io::IO, lscs::LombScargleCrossspectrum{T}) where T
+    print(io, "LombScargleCrossspectrum($(lscs.norm), $(lscs.method), ",
+          "$(length(lscs.freq)) freq bins, ",
+          "df=$(round(lscs.df, sigdigits=4)) Hz, ",
+          "freq range=[$(round(lscs.freq[1], sigdigits=4)), ",
+          "$(round(lscs.freq[end], sigdigits=4))] Hz)")
+end

--- a/src/lombscargle.jl
+++ b/src/lombscargle.jl
@@ -432,3 +432,135 @@ function LombScargleCrossspectrum(ev1::EventList, ev2::EventList;
         min_freq=min_freq, max_freq=max_freq, df=df,
         method=method, oversampling=oversampling)
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LombScarglePowerspectrum
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    LombScarglePowerspectrum{T<:Real} <: AbstractPowerspectrum
+
+A power spectrum (periodogram) computed from an unevenly sampled time series
+using the Lomb-Scargle Fourier Transform.
+
+Mathematically equivalent to a `LombScargleCrossspectrum` of a signal with
+itself. The `nphots` field stores the total number of photons (same as
+`nphots1` in the cross-spectrum).
+
+Mirrors Python Stingray's `LombScarglePowerspectrum`.
+
+# Fields
+Same as `LombScargleCrossspectrum`, plus:
+- `nphots::T`: Total number of photons (equals `nphots1`).
+"""
+struct LombScarglePowerspectrum{T<:Real} <: AbstractPowerspectrum
+    freq::Vector{T}
+    power::Union{Vector{T}, Vector{Complex{T}}}
+    power_err::Union{Vector{T}, Vector{Complex{T}}}
+    unnorm_power::Vector{Complex{T}}
+    unnorm_power_err::Vector{Complex{T}}
+    df::T
+    dt::T
+    n::Int
+    m::Int
+    k::Int
+    nphots::T
+    nphots1::T
+    nphots2::T
+    norm::String
+    power_type::String
+    fullspec::Bool
+    method::String
+    oversampling::Int
+    variance1::T
+    variance2::T
+    err_dist::String
+    type::String
+end
+
+function Base.show(io::IO, lsps::LombScarglePowerspectrum{T}) where T
+    print(io, "LombScarglePowerspectrum($(lsps.norm), $(lsps.method), ",
+          "$(length(lsps.freq)) freq bins, ",
+          "df=$(round(lsps.df, sigdigits=4)) Hz, ",
+          "freq range=[$(round(lsps.freq[1], sigdigits=4)), ",
+          "$(round(lsps.freq[end], sigdigits=4))] Hz)")
+end
+
+"""
+    LombScarglePowerspectrum(lc::LightCurve; kwargs...)
+
+Construct a `LombScarglePowerspectrum` from a `LightCurve` object.
+
+Internally computes the cross-spectrum of the light curve with itself,
+then wraps the result as a power spectrum.
+
+# Keyword Arguments
+- `norm::String="frac"`: Normalization ("frac", "abs", "leahy", "none").
+- `power_type::String="all"`: Power type ("all", "real", "absolute").
+- `fullspec::Bool=false`: Include negative frequencies.
+- `min_freq::Union{Nothing, Real}=nothing`: Minimum frequency.
+- `max_freq::Union{Nothing, Real}=nothing`: Maximum frequency.
+- `df::Union{Nothing, Real}=nothing`: Frequency resolution.
+- `method::String="fast"`: LSFT method ("fast" or "slow").
+- `oversampling::Int=5`: Oversampling factor.
+"""
+function LombScarglePowerspectrum(lc::LightCurve;
+                                   norm::String="frac",
+                                   power_type::String="all",
+                                   fullspec::Bool=false,
+                                   min_freq::Union{Nothing, Real}=nothing,
+                                   max_freq::Union{Nothing, Real}=nothing,
+                                   df::Union{Nothing, Real}=nothing,
+                                   method::String="fast",
+                                   oversampling::Int=5)
+    _validate_ls_inputs(norm, power_type, method, oversampling, fullspec,
+                         min_freq, max_freq)
+
+    # Compute as cross-spectrum of signal with itself
+    cs = lscrossspectrum_from_lightcurve(lc, lc;
+        norm=norm, power_type=power_type, fullspec=fullspec,
+        min_freq=min_freq, max_freq=max_freq, df=df,
+        method=method, oversampling=oversampling)
+
+    return LombScarglePowerspectrum{Float64}(
+        cs.freq, cs.power, cs.power_err,
+        cs.unnorm_power, cs.unnorm_power_err,
+        cs.df, cs.dt, cs.n, cs.m, cs.k,
+        cs.nphots1,  # nphots = nphots1 for auto-spectrum
+        cs.nphots1, cs.nphots2,
+        cs.norm, cs.power_type, cs.fullspec,
+        cs.method, cs.oversampling,
+        cs.variance1, cs.variance2,
+        cs.err_dist, "powerspectrum"
+    )
+end
+
+"""
+    LombScarglePowerspectrum(ev::EventList; dt, kwargs...)
+
+Construct a `LombScarglePowerspectrum` from an `EventList` object.
+
+Converts the event list to a light curve, then delegates to the
+`LightCurve` constructor.
+
+# Keyword Arguments
+- `dt::Real`: Time resolution for binning. **Required.**
+- All other kwargs are passed to the `LightCurve` constructor.
+"""
+function LombScarglePowerspectrum(ev::EventList;
+                                   dt::Real,
+                                   norm::String="frac",
+                                   power_type::String="all",
+                                   fullspec::Bool=false,
+                                   min_freq::Union{Nothing, Real}=nothing,
+                                   max_freq::Union{Nothing, Real}=nothing,
+                                   df::Union{Nothing, Real}=nothing,
+                                   method::String="fast",
+                                   oversampling::Int=5)
+    lc = create_lightcurve(ev, dt)
+
+    return LombScarglePowerspectrum(lc;
+        norm=norm, power_type=power_type, fullspec=fullspec,
+        min_freq=min_freq, max_freq=max_freq, df=df,
+        method=method, oversampling=oversampling)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,3 +23,4 @@ include("test_power_colors.jl")
 
 include("test_crossspectrum.jl")
 include("test_powerspectrum.jl")
+include("test_lombscargle.jl")

--- a/test/test_lombscargle.jl
+++ b/test/test_lombscargle.jl
@@ -266,3 +266,381 @@ end
         @test freqs_full isa Vector{Float64}
     end
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper: build a minimal LightCurve for testing
+# ──────────────────────────────────────────────────────────────────────────────
+
+function _make_test_lc(time::Vector{Float64}, counts::Vector{Int};
+                       dt::Float64=1.0, err_method::Symbol=:poisson)
+    metadata = LightCurveMetadata(
+        "TEST", "TEST", "test_object", 0.0,
+        (time[1], time[end]),
+        dt,
+        [Dict{String,Any}()],
+        Dict{String,Any}()
+    )
+    count_error = err_method == :poisson ?
+        Float64.(max.(sqrt.(counts), 1.0)) : nothing
+    exposure = fill(dt, length(time))
+    properties = EventProperty{Float64}[]
+
+    return LightCurve{Float64}(
+        time, dt, counts, count_error, exposure,
+        properties, metadata, err_method
+    )
+end
+
+function _make_sinusoid_lc(; f_signal=0.5, n_points=500, dt=0.1,
+                              amplitude=50, offset=100, rng=nothing)
+    t = collect(0.0:dt:(n_points-1)*dt)
+    signal = offset .+ round.(Int, amplitude .* sin.(2π .* f_signal .* t))
+    if !isnothing(rng)
+        signal .+= rand(rng, -5:5, length(t))
+    end
+    signal = max.(signal, 0)  # No negative counts
+    return _make_test_lc(t, signal; dt=dt)
+end
+
+function _make_poisson_lc(; n_points=1000, dt=0.1, mean_rate=100, rng=MersenneTwister(42))
+    t = collect(0.0:dt:(n_points-1)*dt)
+    counts = rand(rng, Distributions.Poisson(mean_rate), length(t))
+    return _make_test_lc(t, counts; dt=dt)
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LombScargleCrossspectrum tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@testset "LombScargleCrossspectrum" begin
+    lc1 = _make_sinusoid_lc(f_signal=0.5, n_points=500, dt=0.1)
+    lc2 = _make_sinusoid_lc(f_signal=0.5, n_points=500, dt=0.1,
+                             rng=MersenneTwister(99))
+
+    @testset "basic construction from LightCurves" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        @test lscs isa LombScargleCrossspectrum{Float64}
+        @test lscs isa AbstractCrossspectrum
+    end
+
+    @testset "freq properties" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        @test lscs.freq isa Vector{Float64}
+        @test length(lscs.freq) > 0
+        @test all(lscs.freq .> 0)  # positive frequencies only
+        @test issorted(lscs.freq)
+    end
+
+    @testset "power length matches freq" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        @test length(lscs.power) == length(lscs.freq)
+        @test length(lscs.power_err) == length(lscs.freq)
+        @test length(lscs.unnorm_power) == length(lscs.freq)
+    end
+
+    @testset "power type all → complex" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2; power_type="all")
+        @test eltype(lscs.power) <: Complex
+        @test eltype(lscs.power_err) <: Complex
+    end
+
+    @testset "power_err ≈ power for m=1" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        @test lscs.m == 1
+        @test lscs.power_err ≈ lscs.power ./ sqrt(lscs.m)
+    end
+
+    @testset "normalization none" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2; norm="none")
+        @test lscs.norm == "none"
+    end
+
+    @testset "normalization frac" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2; norm="frac")
+        @test lscs.norm == "frac"
+    end
+
+    @testset "normalization leahy" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2; norm="leahy")
+        @test lscs.norm == "leahy"
+    end
+
+    @testset "normalization abs" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2; norm="abs")
+        @test lscs.norm == "abs"
+    end
+
+    @testset "different norms produce different scales" begin
+        norms = ["frac", "abs", "leahy", "none"]
+        mean_powers = Float64[]
+        for n in norms
+            lscs = LombScargleCrossspectrum(lc1, lc2; norm=n)
+            push!(mean_powers, mean(abs.(lscs.power)))
+        end
+        # Not all the same
+        @test length(unique(round.(mean_powers, sigdigits=3))) > 1
+    end
+
+    @testset "power_type real" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2; power_type="real")
+        @test eltype(lscs.power) <: Real
+        @test lscs.power_type == "real"
+    end
+
+    @testset "power_type absolute" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2; power_type="absolute")
+        @test eltype(lscs.power) <: Real
+        @test all(lscs.power .>= 0)
+        @test lscs.power_type == "absolute"
+    end
+
+    @testset "fullspec includes negative frequencies" begin
+        lscs_half = LombScargleCrossspectrum(lc1, lc2; fullspec=false)
+        lscs_full = LombScargleCrossspectrum(lc1, lc2; fullspec=true)
+        @test length(lscs_full.freq) > length(lscs_half.freq)
+        @test any(lscs_full.freq .< 0)
+        @test lscs_full.fullspec == true
+    end
+
+    @testset "method slow vs fast consistent peak" begin
+        lscs_slow = LombScargleCrossspectrum(lc1, lc2; method="slow")
+        lscs_fast = LombScargleCrossspectrum(lc1, lc2; method="fast")
+        peak_slow = lscs_slow.freq[argmax(abs.(lscs_slow.power))]
+        peak_fast = lscs_fast.freq[argmax(abs.(lscs_fast.power))]
+        @test isapprox(peak_slow, peak_fast, atol=0.2)
+    end
+
+    @testset "sinusoidal signal peak at injected frequency" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2; norm="none")
+        # Skip DC-dominated low frequencies (offset=100 in test signal)
+        mask = lscs.freq .> 0.2
+        peak_freq = lscs.freq[mask][argmax(abs.(lscs.power[mask]))]
+        @test isapprox(peak_freq, 0.5, atol=0.15)
+    end
+
+    @testset "metadata fields" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        @test lscs.n == length(lc1.time)
+        @test lscs.m == 1
+        @test lscs.k == 1
+        @test lscs.nphots1 > 0
+        @test lscs.nphots2 > 0
+        @test lscs.type == "crossspectrum"
+        @test lscs.err_dist in ["poisson", "gauss"]
+    end
+
+    @testset "dt field" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        @test lscs.dt ≈ 0.1
+    end
+
+    @testset "df field ≈ freq spacing" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        if length(lscs.freq) > 1
+            @test lscs.df ≈ (lscs.freq[2] - lscs.freq[1]) atol=1e-10
+        end
+    end
+
+    @testset "Base.show" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        buf = IOBuffer()
+        show(buf, lscs)
+        s = String(take!(buf))
+        @test occursin("LombScargleCrossspectrum", s)
+        @test occursin("freq bins", s)
+    end
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LombScarglePowerspectrum tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@testset "LombScarglePowerspectrum" begin
+    lc = _make_sinusoid_lc(f_signal=0.5, n_points=500, dt=0.1)
+
+    @testset "basic construction" begin
+        lsps = LombScarglePowerspectrum(lc)
+        @test lsps isa LombScarglePowerspectrum{Float64}
+        @test lsps isa AbstractPowerspectrum
+        @test lsps isa AbstractCrossspectrum
+    end
+
+    @testset "nphots equals nphots1" begin
+        lsps = LombScarglePowerspectrum(lc)
+        @test lsps.nphots ≈ lsps.nphots1
+    end
+
+    @testset "type is powerspectrum" begin
+        lsps = LombScarglePowerspectrum(lc)
+        @test lsps.type == "powerspectrum"
+    end
+
+    @testset "power is real for norm=none, power_type=real" begin
+        lsps = LombScarglePowerspectrum(lc; norm="none", power_type="real")
+        @test eltype(lsps.power) <: Real
+    end
+
+    @testset "known sinusoid peak" begin
+        lsps = LombScarglePowerspectrum(lc; norm="none")
+        # Skip DC-dominated low frequencies (offset=100 in test signal)
+        mask = lsps.freq .> 0.2
+        peak_freq = lsps.freq[mask][argmax(abs.(lsps.power[mask]))]
+        @test isapprox(peak_freq, 0.5, atol=0.15)
+    end
+
+    @testset "freq/power lengths match" begin
+        lsps = LombScarglePowerspectrum(lc)
+        @test length(lsps.power) == length(lsps.freq)
+        @test length(lsps.power_err) == length(lsps.freq)
+    end
+
+    @testset "freq is positive and sorted" begin
+        lsps = LombScarglePowerspectrum(lc)
+        @test all(lsps.freq .> 0)
+        @test issorted(lsps.freq)
+    end
+
+    @testset "power_err ≈ power for m=1" begin
+        lsps = LombScarglePowerspectrum(lc)
+        @test lsps.m == 1
+        @test lsps.power_err ≈ lsps.power ./ sqrt(lsps.m)
+    end
+
+    @testset "all norms produce different scales" begin
+        norms = ["frac", "abs", "leahy", "none"]
+        mean_powers = Float64[]
+        for n in norms
+            lsps = LombScarglePowerspectrum(lc; norm=n)
+            push!(mean_powers, mean(abs.(lsps.power)))
+        end
+        @test length(unique(round.(mean_powers, sigdigits=3))) > 1
+    end
+
+    @testset "method slow works" begin
+        lsps = LombScarglePowerspectrum(lc; method="slow")
+        @test lsps.method == "slow"
+        @test length(lsps.freq) > 0
+    end
+
+    @testset "method fast works" begin
+        lsps = LombScarglePowerspectrum(lc; method="fast")
+        @test lsps.method == "fast"
+        @test length(lsps.freq) > 0
+    end
+
+    @testset "fullspec includes negative frequencies" begin
+        lsps_half = LombScarglePowerspectrum(lc; fullspec=false)
+        lsps_full = LombScarglePowerspectrum(lc; fullspec=true)
+        @test length(lsps_full.freq) > length(lsps_half.freq)
+        @test any(lsps_full.freq .< 0)
+    end
+
+    @testset "compute_rms returns sensible values" begin
+        lsps = LombScarglePowerspectrum(lc; norm="frac")
+        min_f = lsps.freq[1]
+        max_f = lsps.freq[end]
+        rms, rms_err = compute_rms(lsps, min_f, max_f)
+        @test rms isa Float64
+        @test rms_err isa Float64
+        @test rms >= 0.0
+        @test rms_err >= 0.0
+    end
+
+    @testset "Base.show" begin
+        lsps = LombScarglePowerspectrum(lc)
+        buf = IOBuffer()
+        show(buf, lsps)
+        s = String(take!(buf))
+        @test occursin("LombScarglePowerspectrum", s)
+        @test occursin("freq bins", s)
+    end
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Edge case tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@testset "LombScargle edge cases" begin
+    @testset "very short time series (2 points)" begin
+        lc = _make_test_lc([0.0, 1.0], [10, 20]; dt=1.0)
+        lsps = LombScarglePowerspectrum(lc; norm="none")
+        @test length(lsps.freq) > 0
+    end
+
+    @testset "all-zero counts → zero power" begin
+        t = collect(0.0:0.1:10.0)
+        lc = _make_test_lc(t, zeros(Int, length(t)); dt=0.1)
+        lsps = LombScarglePowerspectrum(lc; norm="none")
+        @test all(abs.(lsps.power) .< 1e-10)
+    end
+
+    @testset "invalid norm string → error" begin
+        lc = _make_sinusoid_lc()
+        @test_throws Stingray.ValueError LombScarglePowerspectrum(lc; norm="invalid")
+    end
+
+    @testset "invalid power_type → error" begin
+        lc = _make_sinusoid_lc()
+        @test_throws Stingray.ValueError LombScarglePowerspectrum(lc; power_type="invalid")
+    end
+
+    @testset "invalid method → error" begin
+        lc = _make_sinusoid_lc()
+        @test_throws Stingray.ValueError LombScarglePowerspectrum(lc; method="invalid")
+    end
+
+    @testset "min_freq > max_freq → error" begin
+        lc = _make_sinusoid_lc()
+        @test_throws Stingray.ValueError LombScarglePowerspectrum(lc; min_freq=1.0, max_freq=0.1)
+    end
+
+    @testset "negative min_freq → error" begin
+        lc = _make_sinusoid_lc()
+        @test_throws Stingray.ValueError LombScarglePowerspectrum(lc; min_freq=-0.5)
+    end
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# time_lag tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@testset "time_lag" begin
+    lc1 = _make_sinusoid_lc(f_signal=0.5, n_points=500, dt=0.1)
+    lc2 = _make_sinusoid_lc(f_signal=0.5, n_points=500, dt=0.1,
+                             rng=MersenneTwister(99))
+
+    @testset "return type" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        lags = time_lag(lscs)
+        @test lags isa Vector{Float64}
+    end
+
+    @testset "length matches freq" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        lags = time_lag(lscs)
+        @test length(lags) == length(lscs.freq)
+    end
+
+    @testset "identical signals → lags ≈ 0" begin
+        lscs = LombScargleCrossspectrum(lc1, lc1)
+        lags = time_lag(lscs)
+        # For identical signals, all cross-power phases should be 0
+        @test all(abs.(lags) .< 1e-10)
+    end
+
+    @testset "phase_lag consistency" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        ϕ = phase_lag(lscs)
+        lags = time_lag(lscs)
+        expected = ϕ ./ (2π .* lscs.freq)
+        @test lags ≈ expected
+    end
+
+    @testset "phase_lag returns Vector{Float64}" begin
+        lscs = LombScargleCrossspectrum(lc1, lc2)
+        ϕ = phase_lag(lscs)
+        @test ϕ isa Vector{Float64}
+        @test length(ϕ) == length(lscs.freq)
+    end
+end
+

--- a/test/test_lombscargle.jl
+++ b/test/test_lombscargle.jl
@@ -1,0 +1,268 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests for Lomb-Scargle module
+# ──────────────────────────────────────────────────────────────────────────────
+
+using Random
+
+# ──────────────────────────────────────────────────────────────────────────────
+# autofrequency tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@testset "autofrequency" begin
+    @testset "all parameters specified" begin
+        freqs = autofrequency(min_freq=0.1, max_freq=0.5, df=0.1)
+        @test freqs ≈ [0.1, 0.2, 0.3, 0.4, 0.5]
+    end
+
+    @testset "from length" begin
+        freqs = autofrequency(min_freq=0.1, max_freq=0.5, length=10.0)
+        @test freqs ≈ [0.1, 0.2, 0.3, 0.4, 0.5]
+    end
+
+    @testset "from dt (Nyquist)" begin
+        freqs = autofrequency(min_freq=0.1, dt=1.0, length=10.0)
+        @test freqs ≈ [0.1, 0.2, 0.3, 0.4, 0.5]
+    end
+
+    @testset "default min_freq" begin
+        freqs = autofrequency(max_freq=0.5, df=0.2)
+        @test freqs ≈ [0.1, 0.3, 0.5]
+    end
+
+    @testset "nyquist_factor > 1" begin
+        freqs = autofrequency(dt=0.1, df=0.5, nyquist_factor=2)
+        @test freqs[end] ≈ 10.0 atol=0.5
+        @test freqs[end] > 5.0
+    end
+
+    @testset "error: missing df and length" begin
+        @test_throws Stingray.ValueError autofrequency(min_freq=0.01, max_freq=0.5)
+    end
+
+    @testset "error: missing max_freq and dt" begin
+        @test_throws Stingray.ValueError autofrequency(min_freq=0.01, df=1.0)
+    end
+
+    @testset "warning: negative min_freq" begin
+        @test_logs (:warn, r"min_freq must be positive") autofrequency(min_freq=-0.1, max_freq=0.5, df=0.1)
+    end
+
+    @testset "return type" begin
+        freqs = autofrequency(min_freq=0.1, max_freq=0.5, df=0.1)
+        @test freqs isa Vector{Float64}
+    end
+
+    @testset "non-empty result" begin
+        freqs = autofrequency(min_freq=0.1, max_freq=0.5, df=0.1)
+        @test length(freqs) > 0
+    end
+
+    @testset "monotonically increasing" begin
+        freqs = autofrequency(min_freq=0.1, max_freq=2.0, df=0.1)
+        @test all(diff(freqs) .> 0)
+    end
+
+    @testset "uniform spacing" begin
+        freqs = autofrequency(min_freq=0.1, max_freq=2.0, df=0.1)
+        diffs = diff(freqs)
+        @test all(isapprox.(diffs, 0.1, atol=1e-10))
+    end
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# lsft_slow tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@testset "lsft_slow" begin
+    @testset "constant signal" begin
+        t = collect(0.0:0.1:9.9)
+        y = fill(5.0, length(t))
+        freqs = collect(0.1:0.1:5.0)
+        ft = lsft_slow(y, t, freqs)
+        # All power should be near zero for a constant signal (no DC in freq grid)
+        powers = abs2.(ft)
+        # Power at lowest freq should be much less than sum(y)^2
+        @test all(powers .< sum(y)^2)
+    end
+
+    @testset "single sinusoid peak detection" begin
+        t = collect(0.0:0.01:10.0)
+        f_signal = 2.5
+        y = sin.(2π .* f_signal .* t)
+        freqs = collect(0.1:0.1:5.0)
+        ft = lsft_slow(y, t, freqs)
+        powers = abs2.(ft)
+        peak_freq = freqs[argmax(powers)]
+        @test isapprox(peak_freq, f_signal, atol=0.15)
+    end
+
+    @testset "return type" begin
+        t = [0.0, 1.0, 2.0]
+        y = [1.0, 2.0, 3.0]
+        freqs = [0.1, 0.2, 0.3]
+        ft = lsft_slow(y, t, freqs)
+        @test ft isa Vector{ComplexF64}
+    end
+
+    @testset "output length matches freqs" begin
+        t = collect(0.0:0.5:5.0)
+        y = randn(length(t))
+        freqs = collect(0.1:0.05:2.0)
+        ft = lsft_slow(y, t, freqs)
+        @test length(ft) == length(freqs)
+    end
+
+    @testset "matches manual DFT" begin
+        t = [0.0, 1.0, 2.0]
+        y = [1.0, 0.0, -1.0]
+        ν = 0.25
+        expected = sum(y[j] * exp(-2π * im * ν * t[j]) for j in eachindex(y))
+        ft = lsft_slow(y, t, [ν])
+        @test ft[1] ≈ expected
+    end
+
+    @testset "zero signal" begin
+        t = collect(0.0:0.1:5.0)
+        y = zeros(length(t))
+        freqs = collect(0.1:0.1:2.0)
+        ft = lsft_slow(y, t, freqs)
+        @test all(abs.(ft) .≈ 0.0)
+    end
+
+    @testset "input length mismatch error" begin
+        @test_throws ArgumentError lsft_slow([1.0, 2.0], [0.0], [0.1])
+    end
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# lsft_fast tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@testset "lsft_fast" begin
+    @testset "single sinusoid peak detection" begin
+        t = collect(0.0:0.01:10.0)
+        f_signal = 2.5
+        y = sin.(2π .* f_signal .* t)
+        freqs = collect(0.1:0.1:5.0)
+        ft = lsft_fast(y, t, freqs; oversampling=5)
+        powers = abs2.(ft)
+        peak_freq = freqs[argmax(powers)]
+        @test isapprox(peak_freq, f_signal, atol=0.15)
+    end
+
+    @testset "return type" begin
+        t = [0.0, 1.0, 2.0, 3.0, 4.0]
+        y = [1.0, 2.0, 3.0, 2.0, 1.0]
+        freqs = [0.1, 0.2, 0.3, 0.4, 0.5]
+        ft = lsft_fast(y, t, freqs)
+        @test ft isa Vector{ComplexF64}
+    end
+
+    @testset "output length matches freqs" begin
+        t = collect(0.0:0.5:5.0)
+        y = randn(length(t))
+        freqs = collect(0.1:0.05:2.0)
+        ft = lsft_fast(y, t, freqs)
+        @test length(ft) == length(freqs)
+    end
+
+    @testset "consistency with lsft_slow" begin
+        rng = MersenneTwister(42)
+        t = sort(rand(rng, 50) .* 10.0)
+        y = sin.(2π .* 0.5 .* t) .+ 0.1 .* randn(rng, 50)
+        freqs = collect(0.05:0.05:2.0)
+        ft_slow = lsft_slow(y, t, freqs)
+        ft_fast = lsft_fast(y, t, freqs; oversampling=10)
+        # The fast method should find the same peak
+        peak_slow = freqs[argmax(abs2.(ft_slow))]
+        peak_fast = freqs[argmax(abs2.(ft_fast))]
+        @test isapprox(peak_fast, peak_slow, atol=0.1)
+    end
+
+    @testset "higher oversampling improves accuracy" begin
+        t = collect(0.0:0.01:10.0)
+        f_signal = 1.3
+        y = sin.(2π .* f_signal .* t)
+        freqs = collect(0.1:0.1:5.0)
+        ft_low = lsft_fast(y, t, freqs; oversampling=2)
+        ft_high = lsft_fast(y, t, freqs; oversampling=10)
+        ft_ref = lsft_slow(y, t, freqs)
+        # High oversampling should be closer to reference
+        err_low = sum(abs2.(ft_low .- ft_ref))
+        err_high = sum(abs2.(ft_high .- ft_ref))
+        @test err_high <= err_low || isapprox(err_high, err_low, rtol=0.5)
+    end
+
+    @testset "input validation" begin
+        @test_throws ArgumentError lsft_fast([1.0, 2.0], [0.0], [0.1])
+        @test_throws ArgumentError lsft_fast([1.0], [0.0], [0.1]; oversampling=0)
+    end
+
+    @testset "zero signal" begin
+        t = collect(0.0:0.1:5.0)
+        y = zeros(length(t))
+        freqs = collect(0.1:0.1:2.0)
+        ft = lsft_fast(y, t, freqs)
+        @test all(abs.(ft) .< 1e-10)
+    end
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# impose_symmetry_lsft tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+@testset "impose_symmetry_lsft" begin
+    @testset "output length" begin
+        freqs = collect(0.1:0.1:0.5)
+        t = collect(0.0:0.1:5.0)
+        y = sin.(2π .* 0.3 .* t)
+        ft = lsft_slow(y, t, freqs)
+        ft_full, freqs_full = impose_symmetry_lsft(ft, sum(y), length(y), freqs)
+        @test length(ft_full) == 2 * length(freqs) + 1
+        @test length(freqs_full) == 2 * length(freqs) + 1
+    end
+
+    @testset "DC component" begin
+        t = collect(0.0:0.1:5.0)
+        y = fill(3.0, length(t))
+        freqs = collect(0.1:0.1:0.5)
+        ft = lsft_slow(y, t, freqs)
+        ft_full, freqs_full = impose_symmetry_lsft(ft, sum(y), length(y), freqs)
+        dc_idx = findfirst(f -> f ≈ 0.0, freqs_full)
+        @test !isnothing(dc_idx)
+        @test real(ft_full[dc_idx]) ≈ sum(y)
+    end
+
+    @testset "Hermitian symmetry" begin
+        rng = MersenneTwister(123)
+        t = sort(rand(rng, 30) .* 5.0)
+        y = randn(rng, 30)
+        freqs = collect(0.2:0.2:1.0)
+        ft = lsft_slow(y, t, freqs)
+        ft_full, freqs_full = impose_symmetry_lsft(ft, sum(y), length(y), freqs)
+        # For each positive frequency, check conjugate at negative frequency
+        for i in eachindex(freqs)
+            pos_idx = findfirst(f -> f ≈ freqs[i], freqs_full)
+            neg_idx = findfirst(f -> f ≈ -freqs[i], freqs_full)
+            @test !isnothing(pos_idx) && !isnothing(neg_idx)
+            @test ft_full[neg_idx] ≈ conj(ft_full[pos_idx])
+        end
+    end
+
+    @testset "frequency symmetry" begin
+        freqs = collect(0.1:0.1:0.5)
+        ft = zeros(ComplexF64, 5)
+        ft_full, freqs_full = impose_symmetry_lsft(ft, 0.0, 10, freqs)
+        # Frequencies should be symmetric around 0
+        @test freqs_full[1] ≈ -freqs_full[end]
+        @test 0.0 in freqs_full
+    end
+
+    @testset "return types" begin
+        freqs = collect(0.1:0.1:0.5)
+        ft = ones(ComplexF64, 5)
+        ft_full, freqs_full = impose_symmetry_lsft(ft, 5.0, 10, freqs)
+        @test ft_full isa Vector{ComplexF64}
+        @test freqs_full isa Vector{Float64}
+    end
+end


### PR DESCRIPTION
Ports the Lomb-Scargle periodogram module from Python Stingray to Julia.

- Implements `lsft_slow` and `lsft_fast` algorithms for unevenly sampled data
- Adds `LombScargleCrossspectrum` and `LombScarglePowerspectrum` structs with all normalizations (`frac`, `leahy`, `abs`, `none`)
- Includes spectral analysis methods (`time_lag`, `compute_rms`, `phase_lag`)
- Comprehensive test coverage