### PR TITLE
feat: implement Dynamical Powerspectrum and Crossspectrum

### DIFF
--- a/src/Stingray.jl
+++ b/src/Stingray.jl
@@ -94,11 +94,20 @@ export HuePlot
 include("crossspectrum.jl")
 export AbstractCrossspectrum
 export Crossspectrum
+export DynamicalCrossspectrum
 export rebin_data
 export rebin_data_log
+export rebin_frequency
+export rebin_time
+export rebin_by_n_intervals
+export trace_maximum
+export shift_and_add
+export power_colors
+export compute_rms
 
 include("powerspectrum.jl")
 export AbstractPowerspectrum
 export Powerspectrum
+export DynamicalPowerspectrum
 
 end

--- a/src/Stingray.jl
+++ b/src/Stingray.jl
@@ -94,6 +94,8 @@ export HuePlot
 include("crossspectrum.jl")
 export AbstractCrossspectrum
 export Crossspectrum
+export rebin_data
+export rebin_data_log
 
 include("powerspectrum.jl")
 export AbstractPowerspectrum

--- a/src/crossspectrum.jl
+++ b/src/crossspectrum.jl
@@ -546,3 +546,187 @@ function rebin_data_log(x::AbstractVector, y::AbstractVector, f::Real;
     return xbin, ybin_out, ybin_err_out, nsamples
 end
 
+# ──────────────────────────────────────────────────────────────────────────────
+# DynamicalCrossspectrum
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    DynamicalCrossspectrum{T<:Real} <: AbstractCrossspectrum
+
+A dynamical cross spectrum (spectrogram) computed by dividing two time series
+into segments and computing the cross spectrum for each.
+
+The `dyn_ps` matrix has rows indexed by frequency and columns indexed by time
+(segment midpoints).
+
+Mirrors Python Stingray's `DynamicalCrossspectrum`.
+
+# Fields
+- `dyn_ps::Matrix{Complex{T}}`: Frequency × time matrix of cross-spectral powers.
+- `freq::Vector{T}`: Mid-bin frequencies (Hz).
+- `time::Vector{T}`: Mid-point time of each segment (s).
+- `df::T`: Frequency resolution (Hz).
+- `dt::T`: Time resolution of the spectrogram (= `segment_size` initially).
+- `segment_size::T`: Length of each segment (s).
+- `norm::String`: Normalization applied.
+- `gti::Matrix{T}`: Good Time Intervals.
+- `m::Int`: Number of averaged spectra per bin (1 initially).
+- `nphots1::T`: Mean photon count per segment (signal 1).
+- `nphots2::T`: Mean photon count per segment (signal 2).
+- `unnorm_conversion::T`: Mean ratio of normalized to unnormalized power.
+- `type::String`: Always "dynamical_crossspectrum".
+"""
+struct DynamicalCrossspectrum{T<:Real} <: AbstractCrossspectrum
+    dyn_ps::Matrix{Complex{T}}
+    freq::Vector{T}
+    time::Vector{T}
+    df::T
+    dt::T
+    segment_size::T
+    norm::String
+    gti::Matrix{T}
+    m::Int
+    nphots1::T
+    nphots2::T
+    unnorm_conversion::T
+    type::String
+end
+
+"""
+    DynamicalCrossspectrum(ev1::EventList, ev2::EventList, segment_size, dt; kwargs...)
+
+Construct a `DynamicalCrossspectrum` from two `EventList` objects.
+
+# Arguments
+- `ev1::EventList`: Event list for the subject band.
+- `ev2::EventList`: Event list for the reference band.
+- `segment_size::Real`: Length of each segment in seconds.
+- `dt::Real`: Time resolution (sets Nyquist at 0.5/dt Hz).
+
+# Keyword Arguments
+- `norm::String="frac"`: Normalization ("frac", "abs", "leahy", "none").
+- `silent::Bool=false`: Suppress progress bars.
+"""
+function DynamicalCrossspectrum(ev1::EventList, ev2::EventList,
+                                segment_size::Real, dt::Real;
+                                norm::String="frac",
+                                silent::Bool=false)
+    if segment_size < 2 * dt
+        throw(ArgumentError("segment_size must be >= 2 * dt"))
+    end
+
+    common_gti = has_gti(ev1) && has_gti(ev2) ?
+        operations_on_gtis([gti(ev1), gti(ev2)], intersect) :
+        (has_gti(ev1) ? gti(ev1) : gti(ev2))
+
+    result = _cs_all_segments(
+        times(ev1), times(ev2), common_gti,
+        segment_size, dt;
+        norm=norm, silent=silent
+    )
+
+    if isnothing(result)
+        throw(ArgumentError("No valid segments found. Check GTIs and segment_size."))
+    end
+
+    # Stack per-segment spectra into freq × time matrix
+    dyn_ps = hcat(result.all_cs...)
+    dyn_unnorm = hcat(result.all_unnorm_cs...)
+
+    # Compute unnorm_conversion: mean(normalized / unnormalized)
+    conv = dyn_ps ./ dyn_unnorm
+    unnorm_conv = Float64(real(Statistics.mean(filter(!isnan, conv))))
+
+    # Compute segment midpoints
+    tstart, _ = time_intervals_from_gtis(common_gti, segment_size)
+    seg_times = Float64.(tstart .+ 0.5 * segment_size)
+
+    return DynamicalCrossspectrum{Float64}(
+        Complex{Float64}.(dyn_ps),
+        result.freq,
+        seg_times,
+        result.df,
+        Float64(segment_size),
+        Float64(segment_size),
+        norm,
+        common_gti,
+        1,
+        result.nphots1,
+        result.nphots2,
+        unnorm_conv,
+        "dynamical_crossspectrum"
+    )
+end
+
+"""
+    DynamicalCrossspectrum(lc1::LightCurve, lc2::LightCurve, segment_size; kwargs...)
+
+Construct a `DynamicalCrossspectrum` from two `LightCurve` objects.
+
+# Arguments
+- `lc1::LightCurve`: Light curve for the subject band.
+- `lc2::LightCurve`: Light curve for the reference band.
+- `segment_size::Real`: Length of each segment in seconds.
+
+# Keyword Arguments
+- `norm::String="frac"`: Normalization ("frac", "abs", "leahy", "none").
+- `silent::Bool=false`: Suppress progress bars.
+"""
+function DynamicalCrossspectrum(lc1::LightCurve, lc2::LightCurve,
+                                segment_size::Real;
+                                norm::String="frac",
+                                silent::Bool=false)
+    dt_val = lc1.dt isa AbstractVector ? lc1.dt[1] : lc1.dt
+
+    if segment_size < 2 * dt_val
+        throw(ArgumentError("segment_size must be >= 2 * dt"))
+    end
+
+    lc1_gti = [lc1.metadata.time_range[1] lc1.metadata.time_range[2]]
+    lc2_gti = [lc2.metadata.time_range[1] lc2.metadata.time_range[2]]
+    common_gti = operations_on_gtis([lc1_gti, lc2_gti], intersect)
+
+    total_duration = common_gti[1, 2] - common_gti[1, 1]
+    if segment_size > total_duration
+        throw(ArgumentError(
+            "segment_size ($segment_size s) is longer than total duration ($total_duration s)"))
+    end
+
+    result = _cs_all_segments(
+        lc1.time, lc2.time, common_gti,
+        segment_size, dt_val;
+        norm=norm, silent=silent,
+        fluxes1=Float64.(lc1.counts),
+        fluxes2=Float64.(lc2.counts)
+    )
+
+    if isnothing(result)
+        throw(ArgumentError("No valid segments found. Check GTIs and segment_size."))
+    end
+
+    dyn_ps = hcat(result.all_cs...)
+    dyn_unnorm = hcat(result.all_unnorm_cs...)
+    conv = dyn_ps ./ dyn_unnorm
+    unnorm_conv = Float64(real(Statistics.mean(filter(!isnan, conv))))
+
+    tstart, _ = time_intervals_from_gtis(common_gti, segment_size)
+    seg_times = Float64.(tstart .+ 0.5 * segment_size)
+
+    return DynamicalCrossspectrum{Float64}(
+        Complex{Float64}.(dyn_ps),
+        result.freq,
+        seg_times,
+        result.df,
+        Float64(segment_size),
+        Float64(segment_size),
+        norm,
+        common_gti,
+        1,
+        result.nphots1,
+        result.nphots2,
+        unnorm_conv,
+        "dynamical_crossspectrum"
+    )
+end
+
+

--- a/src/crossspectrum.jl
+++ b/src/crossspectrum.jl
@@ -730,3 +730,44 @@ function DynamicalCrossspectrum(lc1::LightCurve, lc2::LightCurve,
 end
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# DynamicalCrossspectrum methods
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    rebin_frequency(dcs::DynamicalCrossspectrum, df_new; method=:mean)
+
+Rebin the frequency axis of the dynamical cross spectrum to a new resolution.
+
+# Arguments
+- `dcs::DynamicalCrossspectrum`: The dynamical cross spectrum.
+- `df_new::Real`: New frequency resolution (must be >= current `df`).
+
+# Keyword Arguments
+- `method::Symbol=:mean`: Rebinning method (`:mean` or `:sum`).
+
+# Returns
+A new `DynamicalCrossspectrum` with the rebinned frequency axis.
+"""
+function rebin_frequency(dcs::DynamicalCrossspectrum, df_new::Real; method::Symbol=:mean)
+    n_time = size(dcs.dyn_ps, 2)
+
+    # Rebin each time column
+    new_freq, col1, _, _ = rebin_data(dcs.freq, real.(dcs.dyn_ps[:, 1]), df_new; method=method)
+    n_freq_new = length(col1)
+
+    new_dyn = Matrix{Complex{Float64}}(undef, n_freq_new, n_time)
+    for j in 1:n_time
+        _, re, _, _ = rebin_data(dcs.freq, real.(dcs.dyn_ps[:, j]), df_new; method=method)
+        _, im_part, _, _ = rebin_data(dcs.freq, imag.(dcs.dyn_ps[:, j]), df_new; method=method)
+        new_dyn[:, j] = re .+ im .* im_part
+    end
+
+    return DynamicalCrossspectrum{Float64}(
+        new_dyn, Float64.(new_freq), dcs.time,
+        Float64(df_new), dcs.dt, dcs.segment_size,
+        dcs.norm, dcs.gti, dcs.m,
+        dcs.nphots1, dcs.nphots2, dcs.unnorm_conversion,
+        dcs.type
+    )
+end

--- a/src/crossspectrum.jl
+++ b/src/crossspectrum.jl
@@ -1019,3 +1019,11 @@ function compute_rms(dcs::DynamicalCrossspectrum, min_freq::Real, max_freq::Real
 
     return (rms=rms, rms_err=rms_err)
 end
+
+function Base.show(io::IO, dcs::DynamicalCrossspectrum)
+    n_freq, n_time = size(dcs.dyn_ps)
+    print(io, "DynamicalCrossspectrum ($(dcs.norm)-normalized, " *
+              "$n_freq freq bins × $n_time time segments, " *
+              "df=$(round(dcs.df, sigdigits=4)) Hz, " *
+              "dt=$(round(dcs.dt, sigdigits=4)) s)")
+end

--- a/src/crossspectrum.jl
+++ b/src/crossspectrum.jl
@@ -930,3 +930,92 @@ function shift_and_add(dcs::DynamicalCrossspectrum, f0_list::AbstractVector;
     return (freq=final_freqs, power=final_powers, m=count,
             df=dcs.df, norm=dcs.norm)
 end
+
+"""
+    power_colors(dcs::DynamicalCrossspectrum; freq_edges, freqs_to_exclude, poisson_power)
+
+Compute power colors for each time segment of the dynamical cross spectrum.
+Uses the real part of the cross power for each segment.
+
+# Keyword Arguments
+- `freq_edges::Vector{Float64}=[1/256, 1/32, 0.25, 2.0, 16.0]`: Frequency band edges.
+- `freqs_to_exclude::Union{Nothing, Vector}=nothing`: Frequency ranges to exclude.
+- `poisson_power::Union{Nothing, Real}=nothing`: Poisson noise level.
+
+# Returns
+`(pc0, pc0_err, pc1, pc1_err)` — Vectors of power colors for each segment.
+"""
+function power_colors(dcs::DynamicalCrossspectrum;
+                      freq_edges::Vector{Float64}=[1/256, 1/32, 0.25, 2.0, 16.0],
+                      freqs_to_exclude::Union{Nothing, Vector}=nothing,
+                      poisson_power::Union{Nothing, Real}=nothing)
+    if isnothing(poisson_power)
+        meanrate = sqrt(dcs.nphots1 * dcs.nphots2) / dcs.segment_size
+        poisson_power = poisson_level(dcs.norm;
+                                      meanrate=meanrate,
+                                      n_ph=sqrt(dcs.nphots1 * dcs.nphots2))
+    end
+
+    n_time = size(dcs.dyn_ps, 2)
+    pc0 = Vector{Float64}(undef, n_time)
+    pc0_err = Vector{Float64}(undef, n_time)
+    pc1 = Vector{Float64}(undef, n_time)
+    pc1_err = Vector{Float64}(undef, n_time)
+
+    for j in 1:n_time
+        p0, p0e, p1, p1e = power_color(
+            dcs.freq, real.(dcs.dyn_ps[:, j]);
+            freq_edges=freq_edges,
+            df=dcs.df, m=dcs.m,
+            freqs_to_exclude=freqs_to_exclude,
+            poisson_power=poisson_power
+        )
+        pc0[j] = p0
+        pc0_err[j] = p0e
+        pc1[j] = p1
+        pc1_err[j] = p1e
+    end
+
+    return (pc0=pc0, pc0_err=pc0_err, pc1=pc1, pc1_err=pc1_err)
+end
+
+"""
+    compute_rms(dcs::DynamicalCrossspectrum, min_freq, max_freq; poisson_noise_level=0)
+
+Compute the fractional RMS for each time segment of the dynamical cross spectrum.
+Uses the real part of the cross power.
+
+# Arguments
+- `dcs::DynamicalCrossspectrum`: The dynamical cross spectrum.
+- `min_freq::Real`: Lower frequency bound for integration.
+- `max_freq::Real`: Upper frequency bound for integration.
+
+# Keyword Arguments
+- `poisson_noise_level::Real=0`: Poisson noise level to subtract.
+
+# Returns
+`(rms, rms_err)` — Vectors of fractional RMS and error for each segment.
+"""
+function compute_rms(dcs::DynamicalCrossspectrum, min_freq::Real, max_freq::Real;
+                     poisson_noise_level::Real=0)
+    n_time = size(dcs.dyn_ps, 2)
+    rms = Vector{Float64}(undef, n_time)
+    rms_err = Vector{Float64}(undef, n_time)
+
+    for j in 1:n_time
+        power_int, power_int_err = integrate_power_in_frequency_range(
+            dcs.freq, real.(dcs.dyn_ps[:, j]), [min_freq, max_freq];
+            df=dcs.df, m=dcs.m,
+            poisson_power=poisson_noise_level
+        )
+        if power_int > 0
+            rms[j] = sqrt(abs(power_int))
+            rms_err[j] = power_int_err / (2 * rms[j])
+        else
+            rms[j] = 0.0
+            rms_err[j] = 0.0
+        end
+    end
+
+    return (rms=rms, rms_err=rms_err)
+end

--- a/src/crossspectrum.jl
+++ b/src/crossspectrum.jl
@@ -894,3 +894,39 @@ function trace_maximum(dcs::DynamicalCrossspectrum;
     end
     return result
 end
+
+"""
+    shift_and_add(dcs::DynamicalCrossspectrum, f0_list; nbins=100, rebin=nothing)
+
+Shift and add the dynamical cross spectrum, centering each segment's
+spectrum on the corresponding frequency in `f0_list`.
+
+Uses the shift-and-add technique for tracking kHz QPOs.
+
+# Arguments
+- `dcs::DynamicalCrossspectrum`: The dynamical cross spectrum.
+- `f0_list::AbstractVector`: Central frequencies, one per time segment.
+
+# Keyword Arguments
+- `nbins::Int=100`: Number of output frequency bins.
+- `rebin::Union{Nothing, Int}=nothing`: Rebin factor for the output.
+
+# Returns
+A NamedTuple `(freq, power, m, df, norm)`.
+"""
+function shift_and_add(dcs::DynamicalCrossspectrum, f0_list::AbstractVector;
+                       nbins::Int=100,
+                       rebin::Union{Nothing, Int}=nothing)
+    n_time = size(dcs.dyn_ps, 2)
+    # Extract power columns as a vector of vectors
+    power_list = [real.(dcs.dyn_ps[:, j]) for j in 1:n_time]
+
+    final_freqs, final_powers, count = Stingray.shift_and_add(
+        dcs.freq, power_list, f0_list;
+        nbins=nbins, rebin=rebin, df=dcs.df,
+        M=fill(dcs.m, n_time)
+    )
+
+    return (freq=final_freqs, power=final_powers, m=count,
+            df=dcs.df, norm=dcs.norm)
+end

--- a/src/crossspectrum.jl
+++ b/src/crossspectrum.jl
@@ -306,3 +306,243 @@ function Crossspectrum(lc1::LightCurve, lc2::LightCurve,
         err_dist, "crossspectrum"
     )
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Rebinning utilities
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    rebin_data(x, y, dx_new; yerr=nothing, method=:mean, dx=nothing)
+
+Rebin data to a new resolution `dx_new`. Either sum or average the data points
+in the new bins. Handles partial bins at edges using fractional overlap.
+
+Mirrors Python Stingray's `stingray.utils.rebin_data`.
+
+# Arguments
+- `x::AbstractVector`: The dependent variable (e.g., frequencies).
+- `y::AbstractVector`: The independent variable to be binned (real or complex).
+- `dx_new::Real`: The new resolution of `x`.
+
+# Keyword Arguments
+- `yerr::Union{Nothing, AbstractVector}`: Uncertainties on `y`. Propagated via
+  quadrature during binning.
+- `method::Symbol`: `:mean` (average) or `:sum`. Default `:mean`.
+- `dx::Union{Nothing, Real}`: The old resolution. If `nothing`, computed from
+  `diff(x)`.
+
+# Returns
+- `(xbin, ybin, ybinerr, step_size)` — rebinned x midpoints, rebinned y values,
+  propagated errors, and the number of old bins per new bin.
+"""
+function rebin_data(x::AbstractVector, y::AbstractVector, dx_new::Real;
+                    yerr::Union{Nothing, AbstractVector}=nothing,
+                    method::Symbol=:mean,
+                    dx::Union{Nothing, Real}=nothing)
+
+    y = collect(y)
+    if isnothing(yerr)
+        yerr_arr = zeros(Float64, length(y))
+    else
+        yerr_arr = collect(yerr)
+    end
+
+    # Determine old resolution
+    if isnothing(dx) || dx == 0
+        dx_old = diff(x)
+    else
+        dx_old = [float(dx)]
+    end
+
+    if any(dx_new .< dx_old)
+        throw(ArgumentError(
+            "New frequency resolution must be larger than old frequency resolution."))
+    end
+
+    # Left and right bin edges — assumes x values are left bin edges
+    xedges = vcat(collect(Float64, x), [Float64(x[end]) + dx_old[end]])
+
+    # New regularly-binned edges
+    xbin_edges = collect(xedges[1]:dx_new:(xedges[end] + dx_new))
+
+    n_new = length(xbin_edges) - 1
+    T_out = eltype(y)
+
+    output = zeros(T_out, n_new)
+    outputvar = zeros(Float64, n_new)
+    step_size = zeros(Float64, n_new)
+
+    all_x = [searchsortedfirst(xedges, xb) for xb in xbin_edges]
+
+    for i in 1:n_new
+        min_ind = all_x[i]
+        max_ind = all_x[i + 1]
+        xmin = xbin_edges[i]
+        xmax = xbin_edges[i + 1]
+
+        for j in min_ind:(max_ind - 2)
+            if 1 <= j <= length(y)
+                output[i] += y[j]
+                outputvar[i] += abs(yerr_arr[j])^2
+                step_size[i] += 1.0
+            end
+        end
+
+        if min_ind >= 2 && min_ind - 1 <= length(y)
+            prev_dx = xedges[min_ind] - xedges[min_ind - 1]
+            prev_frac = (xedges[min_ind] - xmin) / prev_dx
+            output[i] += y[min_ind - 1] * prev_frac
+            outputvar[i] += (abs(yerr_arr[min_ind - 1]) * prev_frac)^2
+            step_size[i] += prev_frac
+        end
+
+        if max_ind <= length(xedges) && max_ind - 1 >= 1 && max_ind - 1 <= length(y)
+            dx_post = xedges[max_ind] - xedges[max_ind - 1]
+            post_frac = (xmax - xedges[max_ind - 1]) / dx_post
+            output[i] += y[max_ind - 1] * post_frac
+            outputvar[i] += (abs(yerr_arr[max_ind - 1]) * post_frac)^2
+            step_size[i] += post_frac
+        end
+    end
+
+    if method in (:mean, :avg, :average)
+        ybin = output ./ step_size
+        ybinerr = sqrt.(outputvar) ./ step_size
+    elseif method == :sum
+        ybin = output
+        ybinerr = sqrt.(outputvar)
+    else
+        throw(ArgumentError(
+            "Method not recognized. Please use :sum or :mean."))
+    end
+
+    tseg = length(dx_old) == 1 ?
+        Float64(x[end]) - Float64(x[1]) + dx_old[1] :
+        Float64(x[end]) - Float64(x[1]) + dx_old[end]
+
+    if (tseg / dx_new) % 1 > 0
+        ybin = ybin[1:end-1]
+        ybinerr = ybinerr[1:end-1]
+        step_size = step_size[1:end-1]
+    end
+
+    while length(step_size) > 0 && step_size[end] <= 0
+        ybin = ybin[1:end-1]
+        ybinerr = ybinerr[1:end-1]
+        step_size = step_size[1:end-1]
+    end
+
+    n_out = length(ybin)
+    xbin = [xbin_edges[i] + dx_new / 2 for i in 1:n_out]
+
+    return xbin, ybin, ybinerr, step_size
+end
+
+"""
+    _root_squared_mean(x)
+
+Compute √(mean(x²)) — the root-mean-square statistic used for error
+propagation during logarithmic rebinning.
+"""
+_root_squared_mean(x) = sqrt(mean(x .^ 2))
+
+"""
+    rebin_data_log(x, y, f; y_err=nothing, dx=nothing)
+
+Logarithmic re-bin of data. Each new bin width grows as `dν_j = dν_{j-1} * (1+f)`.
+
+Mirrors Python Stingray's `stingray.utils.rebin_data_log`.
+
+# Arguments
+- `x::AbstractVector`: The dependent variable (e.g., frequencies).
+- `y::AbstractVector`: The independent variable to be binned (real or complex).
+- `f::Real`: The factor of increase of each bin width relative to the previous one.
+
+# Keyword Arguments
+- `y_err::Union{Nothing, AbstractVector}`: Uncertainties on `y`.
+- `dx::Union{Nothing, Real}`: Initial bin width. If `nothing`, computed as `median(diff(x))`.
+
+# Returns
+- `(xbin, ybin, ybin_err, nsamples)` — rebinned midpoints, rebinned values,
+  propagated errors, and number of original samples per bin.
+"""
+function rebin_data_log(x::AbstractVector, y::AbstractVector, f::Real;
+                        y_err::Union{Nothing, AbstractVector}=nothing,
+                        dx::Union{Nothing, Real}=nothing)
+
+    x = Float64.(collect(x))
+    y = collect(y)
+    y_err_arr = isnothing(y_err) ? zeros(Float64, length(y)) : collect(y_err)
+
+    if length(x) != length(y)
+        throw(ArgumentError("x and y must be of the same length!"))
+    end
+    if length(y) != length(y_err_arr)
+        throw(ArgumentError("y and y_err must be of the same length!"))
+    end
+
+    dx_init = isnothing(dx) ? median(diff(x)) : Float64(dx)
+
+    minx = x[1] * 0.5
+    maxx = x[end]
+    binx = [minx, minx + dx_init]
+    dx_curr = dx_init
+
+    while binx[end] <= maxx
+        push!(binx, binx[end] + dx_curr * (1.0 + f))
+        dx_curr = binx[end] - binx[end-1]
+    end
+
+    binx_edges = Float64.(binx)
+    n_bins = length(binx_edges) - 1
+
+    bin_indices = zeros(Int, length(x))
+    for (j, xv) in enumerate(x)
+        idx = searchsortedlast(binx_edges, xv)
+        if idx >= 1 && idx <= n_bins
+            bin_indices[j] = idx
+        end
+    end
+
+    xbin = Vector{Float64}()
+    ybin_real = Vector{Float64}()
+    ybin_imag = Vector{Float64}()
+    ybin_err_real = Vector{Float64}()
+    ybin_err_imag = Vector{Float64}()
+    nsamples = Vector{Int}()
+
+    is_complex = eltype(y) <: Complex
+
+    for i in 1:n_bins
+        mask = bin_indices .== i
+        count = sum(mask)
+        count == 0 && continue
+
+        push!(xbin, mean(x[mask]))
+
+        vals = y[mask]
+        push!(ybin_real, mean(real.(vals)))
+        if is_complex
+            push!(ybin_imag, mean(imag.(vals)))
+        end
+
+        errs = y_err_arr[mask]
+        push!(ybin_err_real, _root_squared_mean(real.(errs)))
+        if is_complex
+            push!(ybin_err_imag, _root_squared_mean(imag.(errs)))
+        end
+
+        push!(nsamples, count)
+    end
+
+    if is_complex
+        ybin_out = ybin_real .+ im .* ybin_imag
+        ybin_err_out = ybin_err_real .+ im .* ybin_err_imag
+    else
+        ybin_out = ybin_real
+        ybin_err_out = ybin_err_real
+    end
+
+    return xbin, ybin_out, ybin_err_out, nsamples
+end
+

--- a/src/crossspectrum.jl
+++ b/src/crossspectrum.jl
@@ -771,3 +771,87 @@ function rebin_frequency(dcs::DynamicalCrossspectrum, df_new::Real; method::Symb
         dcs.type
     )
 end
+
+"""
+    rebin_time(dcs::DynamicalCrossspectrum, dt_new; method=:mean)
+
+Rebin the time axis of the dynamical cross spectrum to a new resolution.
+
+# Arguments
+- `dcs::DynamicalCrossspectrum`: The dynamical cross spectrum.
+- `dt_new::Real`: New time resolution (must be >= current `dt`).
+
+# Keyword Arguments
+- `method::Symbol=:mean`: Rebinning method (`:mean` or `:sum`).
+
+# Returns
+A new `DynamicalCrossspectrum` with the rebinned time axis.
+"""
+function rebin_time(dcs::DynamicalCrossspectrum, dt_new::Real; method::Symbol=:mean)
+    n_freq = size(dcs.dyn_ps, 1)
+
+    new_time, row1, _, _ = rebin_data(dcs.time, real.(dcs.dyn_ps[1, :]), dt_new; method=method)
+    n_time_new = length(row1)
+
+    new_dyn = Matrix{Complex{Float64}}(undef, n_freq, n_time_new)
+    for i in 1:n_freq
+        _, re, _, _ = rebin_data(dcs.time, real.(dcs.dyn_ps[i, :]), dt_new; method=method)
+        _, im_part, _, _ = rebin_data(dcs.time, imag.(dcs.dyn_ps[i, :]), dt_new; method=method)
+        new_dyn[i, :] = re .+ im .* im_part
+    end
+
+    return DynamicalCrossspectrum{Float64}(
+        new_dyn, dcs.freq, Float64.(new_time),
+        dcs.df, Float64(dt_new), dcs.segment_size,
+        dcs.norm, dcs.gti, dcs.m,
+        dcs.nphots1, dcs.nphots2, dcs.unnorm_conversion,
+        dcs.type
+    )
+end
+
+"""
+    rebin_by_n_intervals(dcs::DynamicalCrossspectrum, n; method=:mean)
+
+Average `n` consecutive time segments of the dynamical cross spectrum.
+
+# Arguments
+- `dcs::DynamicalCrossspectrum`: The dynamical cross spectrum.
+- `n::Int`: Number of consecutive segments to average.
+
+# Keyword Arguments
+- `method::Symbol=:mean`: `:mean` (average) or `:sum`.
+
+# Returns
+A new `DynamicalCrossspectrum` with fewer time columns and updated `m` and `dt`.
+"""
+function rebin_by_n_intervals(dcs::DynamicalCrossspectrum, n::Int; method::Symbol=:mean)
+    n_freq, n_time = size(dcs.dyn_ps)
+    n_new = n_time ÷ n
+
+    if n_new < 1
+        throw(ArgumentError("n=$n is larger than the number of time segments ($n_time)"))
+    end
+
+    new_dyn = Matrix{Complex{Float64}}(undef, n_freq, n_new)
+    new_time = Vector{Float64}(undef, n_new)
+
+    for j in 1:n_new
+        cols = ((j-1)*n + 1):(j*n)
+        if method == :mean
+            new_dyn[:, j] = Statistics.mean(dcs.dyn_ps[:, cols], dims=2)
+        else
+            new_dyn[:, j] = sum(dcs.dyn_ps[:, cols], dims=2)
+        end
+        new_time[j] = Statistics.mean(dcs.time[cols])
+    end
+
+    new_m = dcs.m * n
+
+    return DynamicalCrossspectrum{Float64}(
+        new_dyn, dcs.freq, new_time,
+        dcs.df, dcs.dt * n, dcs.segment_size,
+        dcs.norm, dcs.gti, new_m,
+        dcs.nphots1, dcs.nphots2, dcs.unnorm_conversion,
+        dcs.type
+    )
+end

--- a/src/crossspectrum.jl
+++ b/src/crossspectrum.jl
@@ -855,3 +855,42 @@ function rebin_by_n_intervals(dcs::DynamicalCrossspectrum, n::Int; method::Symbo
         dcs.type
     )
 end
+
+"""
+    trace_maximum(dcs::DynamicalCrossspectrum; min_freq=nothing, max_freq=nothing)
+
+Find the frequency index of the maximum |power| for each time segment.
+
+# Arguments
+- `dcs::DynamicalCrossspectrum`: The dynamical cross spectrum.
+
+# Keyword Arguments
+- `min_freq::Union{Nothing, Real}=nothing`: Lower frequency bound.
+- `max_freq::Union{Nothing, Real}=nothing`: Upper frequency bound.
+
+# Returns
+A `Vector{Int}` of frequency indices (into `dcs.freq`) of the peak power
+for each time segment.
+"""
+function trace_maximum(dcs::DynamicalCrossspectrum;
+                       min_freq::Union{Nothing, Real}=nothing,
+                       max_freq::Union{Nothing, Real}=nothing)
+    freq = dcs.freq
+    mask = trues(length(freq))
+    if !isnothing(min_freq)
+        mask .&= freq .>= min_freq
+    end
+    if !isnothing(max_freq)
+        mask .&= freq .<= max_freq
+    end
+    idx_range = findall(mask)
+
+    n_time = size(dcs.dyn_ps, 2)
+    result = Vector{Int}(undef, n_time)
+    for j in 1:n_time
+        col = abs.(dcs.dyn_ps[idx_range, j])
+        local_idx = argmax(col)
+        result[j] = idx_range[local_idx]
+    end
+    return result
+end

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -1117,3 +1117,172 @@ function _cs_all_segments(times1::AbstractVector{<:Real}, times2::AbstractVector
         n_ave,
     )
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Shift-and-add (for tracking kHz QPOs)
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    _safe_array_slice_indices(input_size, center_idx, nbins)
+
+Calculate indices to extract an `nbins`-wide slice centered at `center_idx`
+from an array of size `input_size`, handling edge cases where the slice extends
+beyond the array boundaries.
+
+Mirrors Python Stingray's `fourier._safe_array_slice_indices`.
+
+# Returns
+- `(input_range, output_range)` — UnitRange pairs for indexing the input and output arrays.
+
+# Examples
+```jldoctest
+julia> _safe_array_slice_indices(10, 5, 3)
+(4:6, 1:3)
+
+julia> _safe_array_slice_indices(6, 6, 3)  # slice goes past right edge
+(5:6, 1:2)
+```
+"""
+function _safe_array_slice_indices(input_size::Int, center_idx::Int, nbins::Int)
+    minbin = center_idx - nbins ÷ 2
+    maxbin = minbin + nbins
+
+    if minbin < 1
+        output_range = (1 - minbin + 1):min(nbins, input_size - minbin + 1)
+        input_range = 1:(minbin + nbins)
+    elseif maxbin > input_size + 1
+        output_range = 1:(nbins - (maxbin - input_size - 1))
+        input_range = minbin:input_size
+    else
+        output_range = 1:nbins
+        input_range = minbin:(maxbin - 1)
+    end
+
+    return input_range, output_range
+end
+
+"""
+    _shift_and_average_core(power_list, weight_list, center_indices, nbins)
+
+Core function for shift-and-add: shift each power spectrum to a common center
+and compute the weighted average.
+
+Mirrors Python Stingray's `fourier._shift_and_average_core`.
+
+# Arguments
+- `power_list`: Vector of power spectrum vectors.
+- `weight_list`: Vector of weights for each spectrum.
+- `center_indices`: Vector of center frequency indices for each spectrum.
+- `nbins::Int`: Number of output bins.
+
+# Returns
+- `(output_array, sum_of_weights)` — Weighted average powers and weight sums.
+"""
+function _shift_and_average_core(power_list, weight_list, center_indices, nbins::Int)
+    output_array = zeros(Float64, nbins)
+    sum_of_weights = zeros(Float64, nbins)
+    input_size = length(power_list[1])
+
+    for (idx, array, weight) in zip(center_indices, power_list, weight_list)
+        input_range, output_range = _safe_array_slice_indices(input_size, idx, nbins)
+
+        for (oi, ii) in zip(output_range, input_range)
+            output_array[oi] += real(array[ii]) * weight
+            sum_of_weights[oi] += weight
+        end
+    end
+
+    # Avoid division by zero
+    good = sum_of_weights .> 0
+    output_array[good] ./= sum_of_weights[good]
+
+    return output_array, sum_of_weights
+end
+
+"""
+    shift_and_add(freqs, power_list, f0_list; nbins=100, rebin=nothing, df=nothing, M=nothing)
+
+Shift and add a list of power spectra, centered on different frequencies.
+
+This is the basic operation for the shift-and-add technique used to track
+kHz QPOs in X-ray binaries (e.g. Méndez et al. 1998, ApJ, 494, 65).
+
+Mirrors Python Stingray's `fourier.shift_and_add`.
+
+# Arguments
+- `freqs::AbstractVector`: Frequency array (uniform grid, same for all spectra).
+- `power_list`: Vector of power spectrum vectors, or a matrix with columns as spectra.
+- `f0_list::AbstractVector`: Central frequencies for each spectrum.
+
+# Keyword Arguments
+- `nbins::Int=100`: Number of output frequency bins.
+- `rebin::Union{Nothing, Int}=nothing`: Rebin factor for the output spectrum.
+- `df::Union{Nothing, Real}=nothing`: Frequency resolution. Computed from `freqs` if `nothing`.
+- `M::Union{Nothing, Int, AbstractVector}=nothing`: Number of averaged segments.
+
+# Returns
+- `(final_freqs, final_powers, count)` — Output frequencies, averaged powers, and contributing counts.
+
+# Examples
+```jldoctest
+julia> power_list = [[2, 5, 2, 2, 2], [1, 1, 5, 1, 1], [3, 3, 3, 5, 3]];
+
+julia> freqs = collect(0:4) .* 0.1;
+
+julia> f0_list = [0.1, 0.2, 0.3, 0.4];
+
+julia> f, p, n = shift_and_add(freqs, power_list, f0_list; nbins=5);
+
+julia> n
+5-element Vector{Float64}:
+ 2.0
+ 3.0
+ 3.0
+ 3.0
+ 2.0
+```
+"""
+function shift_and_add(freqs::AbstractVector, power_list, f0_list::AbstractVector;
+                       nbins::Int=100,
+                       rebin::Union{Nothing, Int}=nothing,
+                       df::Union{Nothing, Real}=nothing,
+                       M::Union{Nothing, Int, AbstractVector}=nothing)
+    freqs = Float64.(freqs)
+
+    # Convert matrix columns to list of vectors if needed
+    if power_list isa AbstractMatrix
+        power_list = [power_list[:, j] for j in 1:size(power_list, 2)]
+    end
+
+    if isnothing(M)
+        M = 1
+    end
+    weights = if M isa Int
+        fill(Float64(M), length(power_list))
+    else
+        Float64.(M)
+    end
+
+    # Find the center frequency indices (1-based)
+    center_f_indices = [searchsortedfirst(freqs, f0) for f0 in f0_list]
+
+    final_powers, count = _shift_and_average_core(power_list, weights, center_f_indices, nbins)
+
+    if isnothing(df)
+        df = freqs[2] - freqs[1]
+    end
+
+    # Build output frequency axis centered on mean(f0_list)
+    half = nbins ÷ 2
+    final_freqs = collect((-half):((-half) + nbins - 1)) .* df
+    final_freqs .= final_freqs .- (final_freqs[1] + final_freqs[end]) / 2 .+ Statistics.mean(f0_list)
+
+    if !isnothing(rebin)
+        _, count, _, _ = rebin_data(final_freqs, count, rebin * df)
+        final_freqs, final_powers, _, _ = rebin_data(final_freqs, final_powers, rebin * df)
+        final_powers ./= rebin
+    end
+
+    return final_freqs, final_powers, count
+end
+

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -843,3 +843,277 @@ function integrate_power_in_frequency_range(
 
     return power_integrated, power_err_integrated
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Per-segment spectral collection (for Dynamical Powerspectrum/Crossspectrum)
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    _pds_all_segments(times, gti, segment_size, dt; norm, use_common_mean, silent, fluxes)
+
+Compute the power spectrum for **each** segment individually and return them all
+(instead of averaging). Used by `DynamicalPowerspectrum`.
+
+Mirrors the logic of `avg_pds_from_iterable` / `avg_pds_from_events`, but
+collects per-segment results into vectors.
+
+# Returns
+A NamedTuple with fields:
+- `all_pds::Vector{Vector{Float64}}`: Normalized PDS for each segment.
+- `all_unnorm_pds::Vector{Vector{Float64}}`: Unnormalized PDS for each segment.
+- `freq::Vector{Float64}`: Frequency array (shared across segments).
+- `nphots::Float64`: Mean photon count per segment.
+- `n_bin::Int`: Number of bins per segment.
+- `df::Float64`: Frequency resolution.
+- `n_ave::Int`: Number of valid segments.
+"""
+function _pds_all_segments(times::AbstractVector{<:Real}, gti::AbstractMatrix{<:Real},
+                           segment_size::Real, dt::Real;
+                           norm::String="frac",
+                           use_common_mean::Bool=true,
+                           silent::Bool=false,
+                           fluxes=nothing, errors=nothing)
+    n_bin = round(Int, segment_size / dt)
+    dt = segment_size / n_bin
+
+    flux_iterable = get_flux_iterable_from_segments(times, gti, segment_size;
+                                                     n_bin, fluxes=fluxes,
+                                                     errors=errors)
+
+    local_show_progress = silent ? identity : show_progress
+
+    all_pds = Vector{Float64}[]
+    all_unnorm_pds = Vector{Float64}[]
+    freq = nothing
+    fgt0 = nothing
+    sum_of_photons = 0.0
+    common_variance = nothing
+    n_ave = 0
+
+    for flux in local_show_progress(flux_iterable)
+        if isnothing(flux) || all(iszero, flux)
+            continue
+        end
+
+        variance = nothing
+        if flux isa Tuple
+            flux, err = flux
+            variance = Statistics.mean(err)^2
+        end
+
+        n_bin_seg = length(flux)
+        ft = fft(flux)
+        n_ph = sum(flux)
+        unnorm_power = real.(ft .* conj.(ft))
+
+        sum_of_photons += n_ph
+
+        if !isnothing(variance)
+            common_variance = sum_if_not_none_or_initialize(common_variance, variance)
+        end
+
+        if isnothing(freq)
+            fgt0 = positive_fft_bins(n_bin_seg)
+            freq = fftfreq(n_bin_seg, 1 / dt)[fgt0]
+        end
+
+        keepat!(unnorm_power, fgt0)
+
+        # Normalize per-segment if not using common mean
+        cs_seg = if !use_common_mean
+            mean_flux = n_ph / n_bin_seg
+            normalize_periodograms(
+                unnorm_power, dt, n_bin_seg;
+                mean_flux=mean_flux, n_ph=n_ph,
+                norm=norm, variance=variance,
+            )
+        else
+            copy(unnorm_power)  # placeholder; will normalize after collecting all
+        end
+
+        push!(all_pds, cs_seg)
+        push!(all_unnorm_pds, copy(unnorm_power))
+        n_ave += 1
+    end
+
+    if n_ave == 0
+        return nothing
+    end
+
+    n_ph = sum_of_photons / n_ave
+    common_mean = n_ph / n_bin
+
+    if !isnothing(common_variance)
+        common_variance /= n_ave
+    end
+
+    # If using common mean, normalize all segments now
+    if use_common_mean
+        for i in 1:n_ave
+            all_pds[i] = normalize_periodograms(
+                all_unnorm_pds[i], dt, n_bin;
+                mean_flux=common_mean, n_ph=n_ph,
+                norm=norm, variance=common_variance,
+            )
+        end
+    end
+
+    return (;
+        all_pds, all_unnorm_pds,
+        freq=Float64.(freq),
+        nphots=Float64(n_ph),
+        n_bin, df=1.0 / (dt * n_bin),
+        n_ave,
+    )
+end
+
+"""
+    _cs_all_segments(times1, times2, gti, segment_size, dt; norm, use_common_mean,
+                     silent, fluxes1, fluxes2, power_type)
+
+Compute the cross spectrum for **each** segment individually and return them all
+(instead of averaging). Used by `DynamicalCrossspectrum`.
+
+Mirrors the logic of `avg_cs_from_iterables_quick`, but collects per-segment
+results into vectors.
+
+# Returns
+A NamedTuple with fields:
+- `all_cs::Vector{Vector{Complex{Float64}}}`: Normalized cross spectra per segment.
+- `all_unnorm_cs::Vector{Vector{Complex{Float64}}}`: Unnormalized cross spectra per segment.
+- `freq::Vector{Float64}`: Frequency array (shared across segments).
+- `nphots1::Float64`: Mean photon count per segment (signal 1).
+- `nphots2::Float64`: Mean photon count per segment (signal 2).
+- `n_bin::Int`: Number of bins per segment.
+- `df::Float64`: Frequency resolution.
+- `n_ave::Int`: Number of valid segments.
+"""
+function _cs_all_segments(times1::AbstractVector{<:Real}, times2::AbstractVector{<:Real},
+                          gti::AbstractMatrix{<:Real},
+                          segment_size::Real, dt::Real;
+                          norm::String="frac",
+                          use_common_mean::Bool=true,
+                          silent::Bool=false,
+                          fluxes1=nothing, fluxes2=nothing,
+                          errors1=nothing, errors2=nothing,
+                          power_type::String="all")
+    n_bin = round(Int, segment_size / dt)
+    dt = segment_size / n_bin
+
+    flux_iterable1 = get_flux_iterable_from_segments(
+        times1, gti, segment_size; n_bin, fluxes=fluxes1, errors=errors1
+    )
+    flux_iterable2 = get_flux_iterable_from_segments(
+        times2, gti, segment_size; n_bin, fluxes=fluxes2, errors=errors2
+    )
+
+    local_show_progress = silent ? identity : show_progress
+
+    all_cs = Vector{Complex{Float64}}[]
+    all_unnorm_cs = Vector{Complex{Float64}}[]
+    freq = nothing
+    fgt0 = nothing
+    sum_of_photons1 = 0.0
+    sum_of_photons2 = 0.0
+    common_variance1 = common_variance2 = common_variance = nothing
+    n_ave = 0
+
+    for (flux1, flux2) in local_show_progress(zip(flux_iterable1, flux_iterable2))
+        if isnothing(flux1) || isnothing(flux2) || all(iszero, flux1) || all(iszero, flux2)
+            continue
+        end
+
+        variance1 = variance2 = nothing
+        if flux1 isa Tuple
+            flux1, err1 = flux1
+            variance1 = Statistics.mean(err1)^2
+        end
+        if flux2 isa Tuple
+            flux2, err2 = flux2
+            variance2 = Statistics.mean(err2)^2
+        end
+
+        if isnothing(variance1) || isnothing(variance2)
+            variance1 = variance2 = nothing
+        else
+            common_variance1 = sum_if_not_none_or_initialize(common_variance1, variance1)
+            common_variance2 = sum_if_not_none_or_initialize(common_variance2, variance2)
+        end
+
+        n_bin_seg = length(flux1)
+        ft1 = fft(flux1)
+        ft2 = fft(flux2)
+
+        n_ph1 = sum(flux1)
+        n_ph2 = sum(flux2)
+        n_ph = sqrt(n_ph1 * n_ph2)
+
+        unnorm_power = ft1 .* conj.(ft2)
+
+        sum_of_photons1 += n_ph1
+        sum_of_photons2 += n_ph2
+
+        if isnothing(freq)
+            fgt0 = positive_fft_bins(n_bin_seg)
+            freq = fftfreq(n_bin_seg, 1 / dt)[fgt0]
+        end
+
+        keepat!(unnorm_power, fgt0)
+
+        cs_seg = if !use_common_mean
+            mean_flux = n_ph / n_bin_seg
+            variance = if !isnothing(variance1)
+                sqrt(variance1 * variance2)
+            else
+                nothing
+            end
+            normalize_periodograms(
+                unnorm_power, dt, n_bin_seg;
+                mean_flux=mean_flux, n_ph=n_ph,
+                norm=norm, power_type=power_type, variance=variance,
+            )
+        else
+            Complex{Float64}.(unnorm_power)
+        end
+
+        push!(all_cs, Complex{Float64}.(cs_seg))
+        push!(all_unnorm_cs, Complex{Float64}.(unnorm_power))
+        n_ave += 1
+    end
+
+    if n_ave == 0
+        return nothing
+    end
+
+    n_ph1 = sum_of_photons1 / n_ave
+    n_ph2 = sum_of_photons2 / n_ave
+    n_ph = sqrt(n_ph1 * n_ph2)
+    common_mean = n_ph / n_bin
+
+    if !isnothing(common_variance1)
+        common_variance1 /= n_ave
+        common_variance2 /= n_ave
+        common_variance = sqrt(common_variance1 * common_variance2)
+    end
+
+    # If using common mean, normalize all segments now
+    if use_common_mean
+        for i in 1:n_ave
+            all_cs[i] = Complex{Float64}.(normalize_periodograms(
+                all_unnorm_cs[i], dt, n_bin;
+                mean_flux=common_mean, n_ph=n_ph,
+                norm=norm, power_type=power_type,
+                variance=common_variance,
+            ))
+        end
+    end
+
+    return (;
+        all_cs, all_unnorm_cs,
+        freq=Float64.(freq),
+        nphots1=Float64(n_ph1),
+        nphots2=Float64(n_ph2),
+        n_bin, df=1.0 / (dt * n_bin),
+        n_ave,
+    )
+end

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -1144,20 +1144,32 @@ julia> _safe_array_slice_indices(6, 6, 3)  # slice goes past right edge
 ```
 """
 function _safe_array_slice_indices(input_size::Int, center_idx::Int, nbins::Int)
-    minbin = center_idx - nbins ÷ 2
-    maxbin = minbin + nbins
+    # Convert to 0-based for easier reasoning matching Python
+    input_size0 = input_size
+    center_idx0 = center_idx - 1
+    minbin0 = center_idx0 - nbins ÷ 2
+    maxbin0 = minbin0 + nbins
 
-    if minbin < 1
-        output_range = (1 - minbin + 1):min(nbins, input_size - minbin + 1)
-        input_range = 1:(minbin + nbins)
-    elseif maxbin > input_size + 1
-        output_range = 1:(nbins - (maxbin - input_size - 1))
-        input_range = minbin:input_size
+    if minbin0 < 0
+        out_start0 = -minbin0
+        out_end0 = min(nbins, input_size0 - minbin0)
+        in_start0 = 0
+        in_end0 = minbin0 + nbins
+    elseif maxbin0 > input_size0
+        out_start0 = 0
+        out_end0 = nbins - (maxbin0 - input_size0)
+        in_start0 = minbin0
+        in_end0 = input_size0
     else
-        output_range = 1:nbins
-        input_range = minbin:(maxbin - 1)
+        out_start0 = 0
+        out_end0 = nbins
+        in_start0 = minbin0
+        in_end0 = maxbin0
     end
 
+    input_range = (in_start0 + 1):in_end0
+    output_range = (out_start0 + 1):out_end0
+    
     return input_range, output_range
 end
 

--- a/src/powerspectrum.jl
+++ b/src/powerspectrum.jl
@@ -504,3 +504,38 @@ function trace_maximum(dps::DynamicalPowerspectrum;
     end
     return result
 end
+
+"""
+    shift_and_add(dps::DynamicalPowerspectrum, f0_list; nbins=100, rebin=nothing)
+
+Shift and add the dynamical power spectrum, centering each segment's
+spectrum on the corresponding frequency in `f0_list`.
+
+Uses the shift-and-add technique for tracking kHz QPOs.
+
+# Arguments
+- `dps::DynamicalPowerspectrum`: The dynamical power spectrum.
+- `f0_list::AbstractVector`: Central frequencies, one per time segment.
+
+# Keyword Arguments
+- `nbins::Int=100`: Number of output frequency bins.
+- `rebin::Union{Nothing, Int}=nothing`: Rebin factor for the output.
+
+# Returns
+A NamedTuple `(freq, power, m, df, norm)`.
+"""
+function shift_and_add(dps::DynamicalPowerspectrum, f0_list::AbstractVector;
+                       nbins::Int=100,
+                       rebin::Union{Nothing, Int}=nothing)
+    n_time = size(dps.dyn_ps, 2)
+    power_list = [dps.dyn_ps[:, j] for j in 1:n_time]
+
+    final_freqs, final_powers, count = Stingray.shift_and_add(
+        dps.freq, power_list, f0_list;
+        nbins=nbins, rebin=rebin, df=dps.df,
+        M=fill(dps.m, n_time)
+    )
+
+    return (freq=final_freqs, power=final_powers, m=count,
+            df=dps.df, norm=dps.norm)
+end

--- a/src/powerspectrum.jl
+++ b/src/powerspectrum.jl
@@ -161,3 +161,184 @@ function Powerspectrum(lc::LightCurve, segment_size::Real;
         variance_val, err_dist, "powerspectrum"
     )
 end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DynamicalPowerspectrum
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    DynamicalPowerspectrum{T<:Real} <: AbstractPowerspectrum
+
+A dynamical power spectrum (spectrogram) computed by dividing a single time
+series into segments and computing the power spectrum for each.
+
+The `dyn_ps` matrix has rows indexed by frequency and columns indexed by time
+(segment midpoints). All values are real since it's an auto-spectrum.
+
+Mirrors Python Stingray's `DynamicalPowerspectrum`.
+
+# Fields
+- `dyn_ps::Matrix{T}`: Frequency × time matrix of power spectral density.
+- `freq::Vector{T}`: Mid-bin frequencies (Hz).
+- `time::Vector{T}`: Mid-point time of each segment (s).
+- `df::T`: Frequency resolution (Hz).
+- `dt::T`: Time resolution of the spectrogram (= `segment_size` initially).
+- `segment_size::T`: Length of each segment (s).
+- `norm::String`: Normalization applied.
+- `gti::Matrix{T}`: Good Time Intervals.
+- `m::Int`: Number of averaged spectra per bin (1 initially).
+- `nphots::T`: Mean photon count per segment.
+- `meanrate::T`: Mean count rate (counts/s).
+- `unnorm_conversion::T`: Mean ratio of normalized to unnormalized power.
+- `type::String`: Always "dynamical_powerspectrum".
+"""
+struct DynamicalPowerspectrum{T<:Real} <: AbstractPowerspectrum
+    dyn_ps::Matrix{T}
+    freq::Vector{T}
+    time::Vector{T}
+    df::T
+    dt::T
+    segment_size::T
+    norm::String
+    gti::Matrix{T}
+    m::Int
+    nphots::T
+    meanrate::T
+    unnorm_conversion::T
+    type::String
+end
+
+"""
+    DynamicalPowerspectrum(ev::EventList, segment_size, dt; kwargs...)
+
+Construct a `DynamicalPowerspectrum` from an `EventList`.
+
+# Arguments
+- `ev::EventList`: Event list containing photon arrival times.
+- `segment_size::Real`: Length of each segment in seconds.
+- `dt::Real`: Time resolution (sets Nyquist at 0.5/dt Hz).
+
+# Keyword Arguments
+- `norm::String="frac"`: Normalization ("frac", "abs", "leahy", "none").
+- `silent::Bool=false`: Suppress progress bars.
+"""
+function DynamicalPowerspectrum(ev::EventList, segment_size::Real, dt::Real;
+                                norm::String="frac",
+                                silent::Bool=false)
+    if segment_size < 2 * dt
+        throw(ArgumentError("segment_size must be >= 2 * dt"))
+    end
+
+    ev_gti = has_gti(ev) ? gti(ev) : error("EventList must have GTIs")
+
+    result = _pds_all_segments(
+        times(ev), ev_gti,
+        segment_size, dt;
+        norm=norm, silent=silent
+    )
+
+    if isnothing(result)
+        throw(ArgumentError("No valid segments found. Check GTIs and segment_size."))
+    end
+
+    # Stack per-segment spectra into freq × time matrix
+    dyn_ps = hcat(result.all_pds...)
+    dyn_unnorm = hcat(result.all_unnorm_pds...)
+
+    # Compute unnorm_conversion: mean(normalized / unnormalized)
+    conv = dyn_ps ./ dyn_unnorm
+    unnorm_conv = Float64(Statistics.mean(filter(!isnan, conv)))
+
+    # Compute segment midpoints
+    tstart, _ = time_intervals_from_gtis(ev_gti, segment_size)
+    seg_times = Float64.(tstart .+ 0.5 * segment_size)
+
+    n_bin = result.n_bin
+    meanrate = result.nphots / n_bin / (segment_size / n_bin)
+
+    return DynamicalPowerspectrum{Float64}(
+        Float64.(dyn_ps),
+        result.freq,
+        seg_times,
+        result.df,
+        Float64(segment_size),
+        Float64(segment_size),
+        norm,
+        ev_gti,
+        1,
+        result.nphots,
+        meanrate,
+        unnorm_conv,
+        "dynamical_powerspectrum"
+    )
+end
+
+"""
+    DynamicalPowerspectrum(lc::LightCurve, segment_size; kwargs...)
+
+Construct a `DynamicalPowerspectrum` from a `LightCurve`.
+
+# Arguments
+- `lc::LightCurve`: The input light curve.
+- `segment_size::Real`: Length of each segment in seconds.
+
+# Keyword Arguments
+- `norm::String="frac"`: Normalization ("frac", "abs", "leahy", "none").
+- `silent::Bool=false`: Suppress progress bars.
+"""
+function DynamicalPowerspectrum(lc::LightCurve, segment_size::Real;
+                                norm::String="frac",
+                                silent::Bool=false)
+    dt_val = lc.dt isa AbstractVector ? lc.dt[1] : lc.dt
+
+    if segment_size < 2 * dt_val
+        throw(ArgumentError("segment_size must be >= 2 * dt"))
+    end
+
+    lc_gti = [lc.metadata.time_range[1] lc.metadata.time_range[2]]
+
+    total_duration = lc_gti[1, 2] - lc_gti[1, 1]
+    if segment_size > total_duration
+        throw(ArgumentError(
+            "segment_size ($segment_size s) is longer than total duration ($total_duration s)"))
+    end
+
+    result = _pds_all_segments(
+        lc.time, lc_gti,
+        segment_size, dt_val;
+        norm=norm, silent=silent,
+        fluxes=Float64.(lc.counts)
+    )
+
+    if isnothing(result)
+        throw(ArgumentError("No valid segments found. Check GTIs and segment_size."))
+    end
+
+    dyn_ps = hcat(result.all_pds...)
+    dyn_unnorm = hcat(result.all_unnorm_pds...)
+    conv = dyn_ps ./ dyn_unnorm
+    unnorm_conv = Float64(Statistics.mean(filter(!isnan, conv)))
+
+    tstart, _ = time_intervals_from_gtis(lc_gti, segment_size)
+    seg_times = Float64.(tstart .+ 0.5 * segment_size)
+
+    n_bin = result.n_bin
+    meanrate = result.nphots / n_bin / dt_val
+
+    return DynamicalPowerspectrum{Float64}(
+        Float64.(dyn_ps),
+        result.freq,
+        seg_times,
+        result.df,
+        Float64(segment_size),
+        Float64(segment_size),
+        norm,
+        lc_gti,
+        1,
+        result.nphots,
+        meanrate,
+        unnorm_conv,
+        "dynamical_powerspectrum"
+    )
+end
+

--- a/src/powerspectrum.jl
+++ b/src/powerspectrum.jl
@@ -539,3 +539,95 @@ function shift_and_add(dps::DynamicalPowerspectrum, f0_list::AbstractVector;
     return (freq=final_freqs, power=final_powers, m=count,
             df=dps.df, norm=dps.norm)
 end
+
+"""
+    power_colors(dps::DynamicalPowerspectrum; freq_edges, freqs_to_exclude, poisson_power)
+
+Compute power colors for each time segment of the dynamical power spectrum.
+
+Calls `power_color` for each segment independently.
+
+# Keyword Arguments
+- `freq_edges::Vector{Float64}=[1/256, 1/32, 0.25, 2.0, 16.0]`: Frequency band edges.
+- `freqs_to_exclude::Union{Nothing, Vector}=nothing`: Frequency ranges to exclude.
+- `poisson_power::Union{Nothing, Real}=nothing`: Poisson noise level.
+  If `nothing`, computed from the normalization and mean rate.
+
+# Returns
+`(pc0, pc0_err, pc1, pc1_err)` — Vectors of power colors for each segment.
+"""
+function power_colors(dps::DynamicalPowerspectrum;
+                      freq_edges::Vector{Float64}=[1/256, 1/32, 0.25, 2.0, 16.0],
+                      freqs_to_exclude::Union{Nothing, Vector}=nothing,
+                      poisson_power::Union{Nothing, Real}=nothing)
+    if isnothing(poisson_power)
+        poisson_power = poisson_level(dps.norm;
+                                      meanrate=dps.meanrate,
+                                      n_ph=dps.nphots)
+    end
+
+    n_time = size(dps.dyn_ps, 2)
+    pc0 = Vector{Float64}(undef, n_time)
+    pc0_err = Vector{Float64}(undef, n_time)
+    pc1 = Vector{Float64}(undef, n_time)
+    pc1_err = Vector{Float64}(undef, n_time)
+
+    for j in 1:n_time
+        p0, p0e, p1, p1e = power_color(
+            dps.freq, dps.dyn_ps[:, j];
+            freq_edges=freq_edges,
+            df=dps.df, m=dps.m,
+            freqs_to_exclude=freqs_to_exclude,
+            poisson_power=poisson_power
+        )
+        pc0[j] = p0
+        pc0_err[j] = p0e
+        pc1[j] = p1
+        pc1_err[j] = p1e
+    end
+
+    return (pc0=pc0, pc0_err=pc0_err, pc1=pc1, pc1_err=pc1_err)
+end
+
+"""
+    compute_rms(dps::DynamicalPowerspectrum, min_freq, max_freq; poisson_noise_level=0)
+
+Compute the fractional RMS for each time segment of the dynamical power spectrum.
+
+Uses `integrate_power_in_frequency_range` on each segment.
+
+# Arguments
+- `dps::DynamicalPowerspectrum`: The dynamical power spectrum.
+- `min_freq::Real`: Lower frequency bound for integration.
+- `max_freq::Real`: Upper frequency bound for integration.
+
+# Keyword Arguments
+- `poisson_noise_level::Real=0`: Poisson noise level to subtract.
+
+# Returns
+`(rms, rms_err)` — Vectors of fractional RMS and error for each segment.
+"""
+function compute_rms(dps::DynamicalPowerspectrum, min_freq::Real, max_freq::Real;
+                     poisson_noise_level::Real=0)
+    n_time = size(dps.dyn_ps, 2)
+    rms = Vector{Float64}(undef, n_time)
+    rms_err = Vector{Float64}(undef, n_time)
+
+    for j in 1:n_time
+        power_int, power_int_err = integrate_power_in_frequency_range(
+            dps.freq, dps.dyn_ps[:, j], [min_freq, max_freq];
+            df=dps.df, m=dps.m,
+            poisson_power=poisson_noise_level
+        )
+        # Fractional RMS = sqrt(integrated_power) if frac-normalized
+        if power_int > 0
+            rms[j] = sqrt(abs(power_int))
+            rms_err[j] = power_int_err / (2 * rms[j])
+        else
+            rms[j] = 0.0
+            rms_err[j] = 0.0
+        end
+    end
+
+    return (rms=rms, rms_err=rms_err)
+end

--- a/src/powerspectrum.jl
+++ b/src/powerspectrum.jl
@@ -465,3 +465,42 @@ function rebin_by_n_intervals(dps::DynamicalPowerspectrum, n::Int; method::Symbo
         dps.type
     )
 end
+
+"""
+    trace_maximum(dps::DynamicalPowerspectrum; min_freq=nothing, max_freq=nothing)
+
+Find the frequency index of the maximum power for each time segment.
+
+# Arguments
+- `dps::DynamicalPowerspectrum`: The dynamical power spectrum.
+
+# Keyword Arguments
+- `min_freq::Union{Nothing, Real}=nothing`: Lower frequency bound.
+- `max_freq::Union{Nothing, Real}=nothing`: Upper frequency bound.
+
+# Returns
+A `Vector{Int}` of frequency indices (into `dps.freq`) of the peak power
+for each time segment.
+"""
+function trace_maximum(dps::DynamicalPowerspectrum;
+                       min_freq::Union{Nothing, Real}=nothing,
+                       max_freq::Union{Nothing, Real}=nothing)
+    freq = dps.freq
+    mask = trues(length(freq))
+    if !isnothing(min_freq)
+        mask .&= freq .>= min_freq
+    end
+    if !isnothing(max_freq)
+        mask .&= freq .<= max_freq
+    end
+    idx_range = findall(mask)
+
+    n_time = size(dps.dyn_ps, 2)
+    result = Vector{Int}(undef, n_time)
+    for j in 1:n_time
+        col = dps.dyn_ps[idx_range, j]
+        local_idx = argmax(col)
+        result[j] = idx_range[local_idx]
+    end
+    return result
+end

--- a/src/powerspectrum.jl
+++ b/src/powerspectrum.jl
@@ -631,3 +631,11 @@ function compute_rms(dps::DynamicalPowerspectrum, min_freq::Real, max_freq::Real
 
     return (rms=rms, rms_err=rms_err)
 end
+
+function Base.show(io::IO, dps::DynamicalPowerspectrum)
+    n_freq, n_time = size(dps.dyn_ps)
+    print(io, "DynamicalPowerspectrum ($(dps.norm)-normalized, " *
+              "$n_freq freq bins × $n_time time segments, " *
+              "df=$(round(dps.df, sigdigits=4)) Hz, " *
+              "dt=$(round(dps.dt, sigdigits=4)) s)")
+end

--- a/src/powerspectrum.jl
+++ b/src/powerspectrum.jl
@@ -342,3 +342,43 @@ function DynamicalPowerspectrum(lc::LightCurve, segment_size::Real;
     )
 end
 
+# ──────────────────────────────────────────────────────────────────────────────
+# DynamicalPowerspectrum methods
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    rebin_frequency(dps::DynamicalPowerspectrum, df_new; method=:mean)
+
+Rebin the frequency axis of the dynamical power spectrum to a new resolution.
+
+# Arguments
+- `dps::DynamicalPowerspectrum`: The dynamical power spectrum.
+- `df_new::Real`: New frequency resolution (must be >= current `df`).
+
+# Keyword Arguments
+- `method::Symbol=:mean`: Rebinning method (`:mean` or `:sum`).
+
+# Returns
+A new `DynamicalPowerspectrum` with the rebinned frequency axis.
+"""
+function rebin_frequency(dps::DynamicalPowerspectrum, df_new::Real; method::Symbol=:mean)
+    n_time = size(dps.dyn_ps, 2)
+
+    # Rebin each time column
+    new_freq, col1, _, _ = rebin_data(dps.freq, dps.dyn_ps[:, 1], df_new; method=method)
+    n_freq_new = length(col1)
+
+    new_dyn = Matrix{Float64}(undef, n_freq_new, n_time)
+    for j in 1:n_time
+        _, ybin, _, _ = rebin_data(dps.freq, dps.dyn_ps[:, j], df_new; method=method)
+        new_dyn[:, j] = ybin
+    end
+
+    return DynamicalPowerspectrum{Float64}(
+        new_dyn, Float64.(new_freq), dps.time,
+        Float64(df_new), dps.dt, dps.segment_size,
+        dps.norm, dps.gti, dps.m,
+        dps.nphots, dps.meanrate, dps.unnorm_conversion,
+        dps.type
+    )
+end

--- a/src/powerspectrum.jl
+++ b/src/powerspectrum.jl
@@ -382,3 +382,86 @@ function rebin_frequency(dps::DynamicalPowerspectrum, df_new::Real; method::Symb
         dps.type
     )
 end
+
+"""
+    rebin_time(dps::DynamicalPowerspectrum, dt_new; method=:mean)
+
+Rebin the time axis of the dynamical power spectrum to a new resolution.
+
+# Arguments
+- `dps::DynamicalPowerspectrum`: The dynamical power spectrum.
+- `dt_new::Real`: New time resolution (must be >= current `dt`).
+
+# Keyword Arguments
+- `method::Symbol=:mean`: Rebinning method (`:mean` or `:sum`).
+
+# Returns
+A new `DynamicalPowerspectrum` with the rebinned time axis.
+"""
+function rebin_time(dps::DynamicalPowerspectrum, dt_new::Real; method::Symbol=:mean)
+    n_freq = size(dps.dyn_ps, 1)
+
+    new_time, row1, _, _ = rebin_data(dps.time, dps.dyn_ps[1, :], dt_new; method=method)
+    n_time_new = length(row1)
+
+    new_dyn = Matrix{Float64}(undef, n_freq, n_time_new)
+    for i in 1:n_freq
+        _, ybin, _, _ = rebin_data(dps.time, dps.dyn_ps[i, :], dt_new; method=method)
+        new_dyn[i, :] = ybin
+    end
+
+    return DynamicalPowerspectrum{Float64}(
+        new_dyn, dps.freq, Float64.(new_time),
+        dps.df, Float64(dt_new), dps.segment_size,
+        dps.norm, dps.gti, dps.m,
+        dps.nphots, dps.meanrate, dps.unnorm_conversion,
+        dps.type
+    )
+end
+
+"""
+    rebin_by_n_intervals(dps::DynamicalPowerspectrum, n; method=:mean)
+
+Average `n` consecutive time segments of the dynamical power spectrum.
+
+# Arguments
+- `dps::DynamicalPowerspectrum`: The dynamical power spectrum.
+- `n::Int`: Number of consecutive segments to average.
+
+# Keyword Arguments
+- `method::Symbol=:mean`: `:mean` (average) or `:sum`.
+
+# Returns
+A new `DynamicalPowerspectrum` with fewer time columns and updated `m` and `dt`.
+"""
+function rebin_by_n_intervals(dps::DynamicalPowerspectrum, n::Int; method::Symbol=:mean)
+    n_freq, n_time = size(dps.dyn_ps)
+    n_new = n_time ÷ n
+
+    if n_new < 1
+        throw(ArgumentError("n=$n is larger than the number of time segments ($n_time)"))
+    end
+
+    new_dyn = Matrix{Float64}(undef, n_freq, n_new)
+    new_time = Vector{Float64}(undef, n_new)
+
+    for j in 1:n_new
+        cols = ((j-1)*n + 1):(j*n)
+        if method == :mean
+            new_dyn[:, j] = Statistics.mean(dps.dyn_ps[:, cols], dims=2)
+        else
+            new_dyn[:, j] = sum(dps.dyn_ps[:, cols], dims=2)
+        end
+        new_time[j] = Statistics.mean(dps.time[cols])
+    end
+
+    new_m = dps.m * n
+
+    return DynamicalPowerspectrum{Float64}(
+        new_dyn, dps.freq, new_time,
+        dps.df, dps.dt * n, dps.segment_size,
+        dps.norm, dps.gti, new_m,
+        dps.nphots, dps.meanrate, dps.unnorm_conversion,
+        dps.type
+    )
+end

--- a/test/test_crossspectrum.jl
+++ b/test/test_crossspectrum.jl
@@ -149,3 +149,147 @@ using Stingray
     end
 
 end
+
+@testset "DynamicalCrossspectrum" begin
+
+    test_gti = [0.0 100.0]
+
+    function make_eventlist_with_gti(t, gti_matrix)
+        meta = FITSMetadata(
+            "[test]", 1, nothing,
+            Dict{String,Vector}(), Dict{String,Any}(),
+            gti_matrix, nothing, nothing, nothing,
+            nothing, nothing, nothing, nothing
+        )
+        EventList(t, nothing, meta)
+    end
+
+    # Create test data: 100s of events, ~100 counts/s
+    rng = MersenneTwister(20240101)
+    times1 = sort(rand(rng, Uniform(0.0, 100.0), 10000))
+    times2 = sort(rand(rng, Uniform(0.0, 100.0), 8000))
+    ev1 = make_eventlist_with_gti(times1, test_gti)
+    ev2 = make_eventlist_with_gti(times2, test_gti)
+    dt = 0.01
+    segment_size = 10.0
+
+    @testset "EventList constructor" begin
+        dcs = DynamicalCrossspectrum(ev1, ev2, segment_size, dt; norm="frac", silent=true)
+
+        @test dcs isa DynamicalCrossspectrum{Float64}
+        @test dcs isa AbstractCrossspectrum
+        @test dcs.type == "dynamical_crossspectrum"
+        @test dcs.norm == "frac"
+        @test length(dcs.freq) > 0
+        @test length(dcs.time) > 0
+        @test dcs.df > 0
+        @test dcs.dt == segment_size
+        @test dcs.m == 1
+        @test dcs.nphots1 > 0
+        @test dcs.nphots2 > 0
+        @test eltype(dcs.dyn_ps) <: Complex
+    end
+
+    @testset "Matrix shape" begin
+        dcs = DynamicalCrossspectrum(ev1, ev2, segment_size, dt; norm="frac", silent=true)
+
+        n_freq, n_time = size(dcs.dyn_ps)
+        @test n_freq == length(dcs.freq)
+        @test n_time == length(dcs.time)
+        # 100s / 10s = 10 segments
+        @test n_time == 10
+    end
+
+    @testset "Bad args - short segment" begin
+        @test_throws ArgumentError DynamicalCrossspectrum(
+            ev1, ev2, 0.001, dt; silent=true)
+    end
+
+    @testset "LightCurve constructor" begin
+        lc1 = create_lightcurve(ev1, dt)
+        lc2 = create_lightcurve(ev2, dt)
+
+        dcs = DynamicalCrossspectrum(lc1, lc2, segment_size; norm="frac", silent=true)
+
+        @test dcs isa DynamicalCrossspectrum{Float64}
+        @test dcs.type == "dynamical_crossspectrum"
+        @test size(dcs.dyn_ps, 2) == length(dcs.time)
+    end
+
+    @testset "LightCurve bad args - long segment" begin
+        lc1 = create_lightcurve(ev1, dt)
+        lc2 = create_lightcurve(ev2, dt)
+
+        @test_throws ArgumentError DynamicalCrossspectrum(
+            lc1, lc2, 200.0; silent=true)
+    end
+
+    @testset "Base.show" begin
+        dcs = DynamicalCrossspectrum(ev1, ev2, segment_size, dt; norm="frac", silent=true)
+        buf = IOBuffer()
+        show(buf, dcs)
+        s = String(take!(buf))
+        @test occursin("DynamicalCrossspectrum", s)
+        @test occursin("frac", s)
+        @test occursin("freq bins", s)
+        @test occursin("time segments", s)
+    end
+
+    # Method tests
+    dcs = DynamicalCrossspectrum(ev1, ev2, segment_size, dt; norm="frac", silent=true)
+
+    @testset "rebin_frequency" begin
+        df_new = dcs.df * 5
+        dcs_rb = rebin_frequency(dcs, df_new)
+        @test dcs_rb isa DynamicalCrossspectrum{Float64}
+        @test length(dcs_rb.freq) < length(dcs.freq)
+        @test size(dcs_rb.dyn_ps, 2) == size(dcs.dyn_ps, 2)  # time unchanged
+    end
+
+    @testset "rebin_time" begin
+        dt_new = dcs.dt * 2
+        dcs_rb = rebin_time(dcs, dt_new)
+        @test dcs_rb isa DynamicalCrossspectrum{Float64}
+        @test length(dcs_rb.time) < length(dcs.time)
+        @test size(dcs_rb.dyn_ps, 1) == size(dcs.dyn_ps, 1)  # freq unchanged
+    end
+
+    @testset "rebin_by_n_intervals" begin
+        dcs_rb = rebin_by_n_intervals(dcs, 2)
+        @test dcs_rb isa DynamicalCrossspectrum{Float64}
+        @test size(dcs_rb.dyn_ps, 2) == size(dcs.dyn_ps, 2) ÷ 2
+        @test dcs_rb.m == dcs.m * 2
+    end
+
+    @testset "trace_maximum" begin
+        idx = trace_maximum(dcs)
+        @test length(idx) == size(dcs.dyn_ps, 2)
+        @test all(1 .<= idx .<= length(dcs.freq))
+    end
+
+    @testset "trace_maximum with bounds" begin
+        mid_freq = dcs.freq[length(dcs.freq) ÷ 2]
+        idx = trace_maximum(dcs; min_freq=mid_freq)
+        @test all(dcs.freq[idx] .>= mid_freq)
+    end
+
+    @testset "shift_and_add" begin
+        f0_list = dcs.freq[argmax(abs.(dcs.dyn_ps[:, j])) for j in 1:size(dcs.dyn_ps, 2)]
+        result = shift_and_add(dcs, f0_list; nbins=50)
+        @test haskey(result, :freq)
+        @test haskey(result, :power)
+        @test haskey(result, :m)
+        @test length(result.freq) == 50
+        @test length(result.power) == 50
+    end
+
+    @testset "compute_rms" begin
+        fmin = dcs.freq[2]
+        fmax = dcs.freq[end-1]
+        result = compute_rms(dcs, fmin, fmax)
+        @test length(result.rms) == size(dcs.dyn_ps, 2)
+        @test length(result.rms_err) == size(dcs.dyn_ps, 2)
+        @test all(result.rms .>= 0)
+    end
+
+end

--- a/test/test_crossspectrum.jl
+++ b/test/test_crossspectrum.jl
@@ -274,7 +274,7 @@ end
     end
 
     @testset "shift_and_add" begin
-        f0_list = dcs.freq[argmax(abs.(dcs.dyn_ps[:, j])) for j in 1:size(dcs.dyn_ps, 2)]
+        f0_list = [dcs.freq[argmax(abs.(dcs.dyn_ps[:, j]))] for j in 1:size(dcs.dyn_ps, 2)]
         result = shift_and_add(dcs, f0_list; nbins=50)
         @test haskey(result, :freq)
         @test haskey(result, :power)

--- a/test/test_fourier.jl
+++ b/test/test_fourier.jl
@@ -457,3 +457,49 @@ end
         @test Statistics.mean(pdsnorm)≈Statistics.mean(pds) rtol=0.01
     end
 end
+
+@testset "shift_and_add" begin
+
+    @testset "_safe_array_slice_indices basic" begin
+        ir, or = Stingray._safe_array_slice_indices(10, 5, 3)
+        @test ir == 4:6
+        @test or == 1:3
+    end
+
+    @testset "_safe_array_slice_indices right edge" begin
+        ir, or = Stingray._safe_array_slice_indices(6, 6, 3)
+        @test ir == 5:6
+        @test or == 1:2
+    end
+
+    @testset "_safe_array_slice_indices left edge" begin
+        ir, or = Stingray._safe_array_slice_indices(10, 1, 4)
+        # center_idx=1, nbins=4 => minbin = 1 - 2 = -1
+        @test length(ir) == length(or)
+    end
+
+    @testset "basic shift and add" begin
+        power_list = [[2, 5, 2, 2, 2], [1, 1, 5, 1, 1], [3, 3, 3, 5, 3]]
+        freqs = collect(0:4) .* 0.1
+        f0_list = [0.1, 0.2, 0.3, 0.4]
+
+        f, p, n = shift_and_add(freqs, power_list, f0_list; nbins=5)
+
+        @test length(f) == 5
+        @test length(p) == 5
+        @test length(n) == 5
+        @test n ≈ [2.0, 3.0, 3.0, 3.0, 2.0]
+        @test p ≈ [2.0, 2.0, 5.0, 2.0, 1.5]
+    end
+
+    @testset "shift and add with matrix input" begin
+        power_matrix = Float64[2 1 3; 5 1 3; 2 5 3; 2 1 5; 2 1 3]
+        freqs = collect(0:4) .* 0.1
+        f0_list = [0.1, 0.2, 0.3, 0.4]
+
+        f, p, n = shift_and_add(freqs, power_matrix, f0_list; nbins=5)
+        @test length(f) == 5
+        @test length(p) == 5
+    end
+
+end

--- a/test/test_powerspectrum.jl
+++ b/test/test_powerspectrum.jl
@@ -308,7 +308,7 @@ end
     end
 
     @testset "shift_and_add" begin
-        f0_list = dps.freq[argmax(dps.dyn_ps[:, j]) for j in 1:size(dps.dyn_ps, 2)]
+        f0_list = [dps.freq[argmax(dps.dyn_ps[:, j])] for j in 1:size(dps.dyn_ps, 2)]
         result = shift_and_add(dps, f0_list; nbins=50)
         @test haskey(result, :freq)
         @test haskey(result, :power)

--- a/test/test_powerspectrum.jl
+++ b/test/test_powerspectrum.jl
@@ -187,3 +187,151 @@ using Stingray
     end
 
 end
+
+@testset "DynamicalPowerspectrum" begin
+
+    test_gti = [0.0 100.0]
+
+    function make_eventlist_with_gti(t, gti_matrix)
+        meta = FITSMetadata(
+            "[test]", 1, nothing,
+            Dict{String,Vector}(), Dict{String,Any}(),
+            gti_matrix, nothing, nothing, nothing,
+            nothing, nothing, nothing, nothing
+        )
+        EventList(t, nothing, meta)
+    end
+
+    # Create test data: 100s of events, ~100 counts/s
+    rng = MersenneTwister(20240202)
+    event_times = sort(rand(rng, Uniform(0.0, 100.0), 10000))
+    ev = make_eventlist_with_gti(event_times, test_gti)
+    dt = 0.01
+    segment_size = 10.0
+
+    @testset "EventList constructor" begin
+        dps = DynamicalPowerspectrum(ev, segment_size, dt; norm="frac", silent=true)
+
+        @test dps isa DynamicalPowerspectrum{Float64}
+        @test dps isa AbstractPowerspectrum
+        @test dps.type == "dynamical_powerspectrum"
+        @test dps.norm == "frac"
+        @test length(dps.freq) > 0
+        @test length(dps.time) > 0
+        @test dps.df > 0
+        @test dps.dt == segment_size
+        @test dps.m == 1
+        @test dps.nphots > 0
+        @test dps.meanrate > 0
+        @test eltype(dps.dyn_ps) <: Real
+    end
+
+    @testset "Matrix shape" begin
+        dps = DynamicalPowerspectrum(ev, segment_size, dt; norm="frac", silent=true)
+
+        n_freq, n_time = size(dps.dyn_ps)
+        @test n_freq == length(dps.freq)
+        @test n_time == length(dps.time)
+        # 100s / 10s = 10 segments
+        @test n_time == 10
+    end
+
+    @testset "Bad args - short segment" begin
+        @test_throws ArgumentError DynamicalPowerspectrum(
+            ev, 0.001, dt; silent=true)
+    end
+
+    @testset "LightCurve constructor" begin
+        lc = create_lightcurve(ev, dt)
+
+        dps = DynamicalPowerspectrum(lc, segment_size; norm="frac", silent=true)
+
+        @test dps isa DynamicalPowerspectrum{Float64}
+        @test dps.type == "dynamical_powerspectrum"
+        @test size(dps.dyn_ps, 2) == length(dps.time)
+    end
+
+    @testset "LightCurve bad args - long segment" begin
+        lc = create_lightcurve(ev, dt)
+
+        @test_throws ArgumentError DynamicalPowerspectrum(
+            lc, 200.0; silent=true)
+    end
+
+    @testset "Base.show" begin
+        dps = DynamicalPowerspectrum(ev, segment_size, dt; norm="frac", silent=true)
+        buf = IOBuffer()
+        show(buf, dps)
+        s = String(take!(buf))
+        @test occursin("DynamicalPowerspectrum", s)
+        @test occursin("frac", s)
+        @test occursin("freq bins", s)
+        @test occursin("time segments", s)
+    end
+
+    # Method tests
+    dps = DynamicalPowerspectrum(ev, segment_size, dt; norm="frac", silent=true)
+
+    @testset "rebin_frequency" begin
+        df_new = dps.df * 5
+        dps_rb = rebin_frequency(dps, df_new)
+        @test dps_rb isa DynamicalPowerspectrum{Float64}
+        @test length(dps_rb.freq) < length(dps.freq)
+        @test size(dps_rb.dyn_ps, 2) == size(dps.dyn_ps, 2)  # time unchanged
+    end
+
+    @testset "rebin_time" begin
+        dt_new = dps.dt * 2
+        dps_rb = rebin_time(dps, dt_new)
+        @test dps_rb isa DynamicalPowerspectrum{Float64}
+        @test length(dps_rb.time) < length(dps.time)
+        @test size(dps_rb.dyn_ps, 1) == size(dps.dyn_ps, 1)  # freq unchanged
+    end
+
+    @testset "rebin_by_n_intervals" begin
+        dps_rb = rebin_by_n_intervals(dps, 2)
+        @test dps_rb isa DynamicalPowerspectrum{Float64}
+        @test size(dps_rb.dyn_ps, 2) == size(dps.dyn_ps, 2) ÷ 2
+        @test dps_rb.m == dps.m * 2
+    end
+
+    @testset "trace_maximum" begin
+        idx = trace_maximum(dps)
+        @test length(idx) == size(dps.dyn_ps, 2)
+        @test all(1 .<= idx .<= length(dps.freq))
+    end
+
+    @testset "trace_maximum with bounds" begin
+        mid_freq = dps.freq[length(dps.freq) ÷ 2]
+        idx = trace_maximum(dps; min_freq=mid_freq)
+        @test all(dps.freq[idx] .>= mid_freq)
+    end
+
+    @testset "shift_and_add" begin
+        f0_list = dps.freq[argmax(dps.dyn_ps[:, j]) for j in 1:size(dps.dyn_ps, 2)]
+        result = shift_and_add(dps, f0_list; nbins=50)
+        @test haskey(result, :freq)
+        @test haskey(result, :power)
+        @test haskey(result, :m)
+        @test length(result.freq) == 50
+        @test length(result.power) == 50
+    end
+
+    @testset "compute_rms" begin
+        fmin = dps.freq[2]
+        fmax = dps.freq[end-1]
+        result = compute_rms(dps, fmin, fmax)
+        @test length(result.rms) == size(dps.dyn_ps, 2)
+        @test length(result.rms_err) == size(dps.dyn_ps, 2)
+        @test all(result.rms .>= 0)
+    end
+
+    @testset "Normalizations" begin
+        for norm in ["frac", "abs", "leahy", "none"]
+            dps_n = DynamicalPowerspectrum(ev, segment_size, dt; norm=norm, silent=true)
+            @test dps_n.norm == norm
+            @test size(dps_n.dyn_ps, 2) > 0
+        end
+    end
+
+end


### PR DESCRIPTION
Implements `DynamicalPowerspectrum` and `DynamicalCrossspectrum` types to compute spectrograms by dividing time series into segments. Includes the shift-and-add algorithm and power colors.